### PR TITLE
Fix Issue #47: do not use '//' as this won't work on *NIX, so use path.join instead

### DIFF
--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -825,7 +825,7 @@ function displayModifiedFiles() {
           let filePaths = document.getElementsByClassName('file-path');
           for (let i = 0; i < filePaths.length; i++) {
             if (filePaths[i].parentElement.className !== "file file-deleted") {
-              let filePath = repoFullPath + "\\" + filePaths[i].innerHTML;
+              let filePath = path.join(repoFullPath, filePaths[i].innerHTML);
               if (!fs.existsSync(filePath)) {
                 filePaths[i].parentElement.remove();
               }
@@ -1233,7 +1233,7 @@ function cleanRepo() {
 
         //Gets NEW/untracked files and deletes them
         function deleteUntrackedFiles(file) {
-          let filePath = repoFullPath + "\\" + file.path();
+          let filePath = path.join(repoFullPath, file.path());
           let modification = calculateModification(file);
           if (modification === "NEW") {
             console.log("DELETING FILE " + filePath);


### PR DESCRIPTION
Fixed Issue #47, which only occurred on non-Windows platforms.

The root cause of the issue is that a '/' was being used in the file path, which is not understood by *NIX.

I used the path.join library to make the path, which knows whether to use a '/' or a '\'.