### PR TITLE
Bug 30 - Pushing changes before committing crashes application

### DIFF
--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -102,7 +102,7 @@ function stage() {
         }
       }
       if (filesToStage.length > 0) {
-        pushButNoCommit = 1;
+        pushButNoCommit = 0;
         console.log("staging files");
         stagedFiles = index.addAll(filesToStage);
       } else {
@@ -117,6 +117,7 @@ function stage() {
       filePanelMessage.parentNode.removeChild(filePanelMessage);
     }
   }
+  pushButNoCommit = 0;
 }
 
 function addAndCommit() {
@@ -221,6 +222,7 @@ function addAndCommit() {
         updateModalText("You have not logged in. Please login to commit a change");
       }
     });
+    pushButNoCommit = 1;
 }
 
 function clearStagedFilesList() {

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -14,7 +14,7 @@ let theirCommit = null;
 let modifiedFiles;
 let warnbool;
 var CommitButNoPush = 0;
-let PushButNoCommit = 0;
+let pushButNoCommit = 0;
 let stagedFiles: any;
 let vis = require("vis");
 let commitHistory = [];
@@ -102,7 +102,7 @@ function stage() {
         }
       }
       if (filesToStage.length > 0) {
-        PushButNoCommit = 1;
+        pushButNoCommit = 1;
         console.log("staging files");
         stagedFiles = index.addAll(filesToStage);
       } else {
@@ -391,7 +391,7 @@ function pushToRemote() {
   let branch = document.getElementById("branch-name").innerText;
 
   // Check to make sure we are not pushing without first committing files
-  if (PushButNoCommit == 0) {
+  if (pushButNoCommit == 0) {
     console.log("There are no staged files")
     displayModal("You have not committed, your push cannot be empty.");
     return;
@@ -419,6 +419,7 @@ function pushToRemote() {
             })
             .then(function () {
               CommitButNoPush = 0;
+              pushButNoCommit = 0;
               window.onbeforeunload = Confirmed;
               console.log("Push successful");
               updateModalText("Push successful");

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -394,8 +394,8 @@ function pushToRemote() {
 
   // Check to make sure we are not pushing without first committing files
   if (pushButNoCommit == 0) {
-    console.log("There are no staged files")
-    displayModal("You have not committed, your push cannot be empty.");
+    console.log("There are no commits available to push")
+    displayModal("You have not committed any files, your push cannot be empty.");
     return;
   }
 

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -14,6 +14,7 @@ let theirCommit = null;
 let modifiedFiles;
 let warnbool;
 var CommitButNoPush = 0;
+let noCommitYesPush = 0;
 let stagedFiles: any;
 let vis = require("vis");
 let commitHistory = [];
@@ -101,6 +102,7 @@ function stage() {
         }
       }
       if (filesToStage.length > 0) {
+        noCommitYesPush = 1;
         console.log("staging files");
         stagedFiles = index.addAll(filesToStage);
       } else {
@@ -387,6 +389,14 @@ function pullFromRemote() {
 
 function pushToRemote() {
   let branch = document.getElementById("branch-name").innerText;
+
+  // Check to make sure we are not pushing without first committing files
+  if (noCommitYesPush == 0) {
+    console.log("There are no staged files")
+    displayModal("You have not committed, your push cannot be empty.");
+    return;
+  }
+
   Git.Repository.open(repoFullPath)
     .then(function (repo) {
       console.log("Pushing changes to remote")

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -14,7 +14,7 @@ let theirCommit = null;
 let modifiedFiles;
 let warnbool;
 var CommitButNoPush = 0;
-let noCommitYesPush = 0;
+let PushButNoCommit = 0;
 let stagedFiles: any;
 let vis = require("vis");
 let commitHistory = [];
@@ -102,7 +102,7 @@ function stage() {
         }
       }
       if (filesToStage.length > 0) {
-        noCommitYesPush = 1;
+        PushButNoCommit = 1;
         console.log("staging files");
         stagedFiles = index.addAll(filesToStage);
       } else {
@@ -391,7 +391,7 @@ function pushToRemote() {
   let branch = document.getElementById("branch-name").innerText;
 
   // Check to make sure we are not pushing without first committing files
-  if (noCommitYesPush == 0) {
+  if (PushButNoCommit == 0) {
     console.log("There are no staged files")
     displayModal("You have not committed, your push cannot be empty.");
     return;


### PR DESCRIPTION
Current fix: If you attempt to push without committing, a dialog block will explain that you cannot push as there are no commits, and will not allow the push function to continue. This is true if you have either un-staged changes or staged changes. If you have committed changes, you will be allowed to push. 

The behaviour of the app crashing after the second push still occurs in our repo as it has not been re-based with the other group's changes where this issue has been fixed (the app will crash after 2 times even with pushes that have commits).

Future plans: Currently, if you commit changes in VisualGit, then exit the app and re-open, the commits will not show and you cannot push because of our check. We would like to solve this case in sprint 2 by checking the diff between local and remote repos, instead of relying on a check based on actions in the app. This will involve more research into nodegit functions. 