### PR TITLE
Issue 8 - Navbar Icons Adjusting Irregularly

### DIFF
--- a/app/components/header/header.component.html
+++ b/app/components/header/header.component.html
@@ -59,7 +59,7 @@
       </ul>
 
       <!--Toolbar-->
-      <ul class="navbar-nav col-md-6 hidden-xs toolbar-Container">
+      <ul class="navbar-nav col hidden-xs toolbar-Container">
         <li class="toolbar-Icons" onclick="openWiki()">
           <i id="wiki-icon" class="fa fa-wikipedia-w fa-2x"></i>
           <span class="toolbar-Text">Wiki</span>

--- a/app/components/header/header.component.html
+++ b/app/components/header/header.component.html
@@ -59,7 +59,7 @@
       </ul>
 
       <!--Toolbar-->
-      <ul class="navbar-nav col-md-4 hidden-xs toolbar-Container">
+      <ul class="navbar-nav col-md-6 hidden-xs toolbar-Container">
         <li class="toolbar-Icons" onclick="openWiki()">
           <i id="wiki-icon" class="fa fa-wikipedia-w fa-2x"></i>
           <span class="toolbar-Text">Wiki</span>

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -734,7 +734,7 @@ div.selected-commit-diff-panel button.close-button {
 
 /*Toolbar Styles*/
 .toolbar-Container {
-  /*max-height: 75px;*/
+  max-height: 65px;
  }
 
 .toolbar-Icons {

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -47,7 +47,7 @@ ul{
   position: relative;
 }
 .navbar .navbar-collapse .navbar-right > li:last-child {
-  padding-left: 22px;
+  padding-left: 30px;
 }
 .navbar .nav-collapse {
   position: absolute;


### PR DESCRIPTION
The issue here seemed to be with the bootstrap grid system having a four-column width, which messed with the icons upon resize. Issue #8 