### PR TITLE
Issue 71 & 72 : double pull or push crash fix and  error handling

### DIFF
--- a/app/misc/authenticate.ts
+++ b/app/misc/authenticate.ts
@@ -80,8 +80,10 @@ function ModalSignIn(callback) {
         getUserInfo(callback);
 }
 
+// provide a fresh cred object. 
+// previously we were trying to use same object again and again which was cauing issues
 function getCredentials(){
-  // might change with Oauth
+  //Note: might change with Oauth
   return Git.Cred.userpassPlaintextNew(getUsernameTemp(), getPasswordTemp());
 }
 

--- a/app/misc/authenticate.ts
+++ b/app/misc/authenticate.ts
@@ -160,7 +160,7 @@ function getUserInfo(callback) {
     encryptTemp(document.getElementById("username").value, document.getElementById("password").value);
   }
 
-  cred = Git.Cred.userpassPlaintextNew(getUsernameTemp(), getPasswordTemp());
+  cred = getCredentials();
 
   // Remove, once Oauth implemented
   client = github.client({

--- a/app/misc/authenticate.ts
+++ b/app/misc/authenticate.ts
@@ -83,7 +83,7 @@ function ModalSignIn(callback) {
 // provide a fresh cred object. 
 // previously we were trying to use same object again and again which was cauing issues
 function getCredentials(){
-  //Note: might change with Oauth
+  //Note: might need to update with Oauth
   return Git.Cred.userpassPlaintextNew(getUsernameTemp(), getPasswordTemp());
 }
 

--- a/app/misc/authenticate.ts
+++ b/app/misc/authenticate.ts
@@ -80,6 +80,10 @@ function ModalSignIn(callback) {
         getUserInfo(callback);
 }
 
+function getCredentials(){
+  // might change with Oauth
+  return Git.Cred.userpassPlaintextNew(getUsernameTemp(), getPasswordTemp());
+}
 
 
 function loginWithSaved(callback) {

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -378,6 +378,8 @@ function pullFromRemote() {
         updateModalText("Successfully pulled from remote branch " + branch + ", and your repo is up to date now!");
         refreshAll(repository);
       }
+      //anywhere during the above process if there is a error the following catch will catch and report it 
+      //and stop the process then and there. 
     }).catch(function(err) {
       console.log(err);
       updateModalText("Pull Failed : "+err.message);

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -340,7 +340,7 @@ function pullFromRemote() {
       return repository.fetchAll({
         callbacks: {
           credentials: function () {
-            return cred;
+            return getCredentials();
           },
           certificateCheck: function () {
             return 1;
@@ -403,7 +403,7 @@ function pushToRemote() {
                 {
                   callbacks: {
                     credentials: function () {
-                      return cred;
+                      return getCredentials();
                     }
                   }
                 }
@@ -559,7 +559,7 @@ function deleteRemoteBranch() {
               {
                 callbacks: { // pass in user credentials as a parameter
                   credentials: function () {
-                    return cred;
+                    return getCredentials();
                   }
                 }
               }).then(function () {

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -395,10 +395,10 @@ function pushToRemote() {
       displayModal("Pushing changes to remote...");
       addCommand("git push -u origin " + branch);
       repo.getRemotes()
-        .then(function (remotes) {
-          repo.getRemote(remotes[0])
-            .then(function (remote) {
-              return remote.push(
+      .then(function (remotes) {
+        repo.getRemote(remotes[0])
+        .then(function (remote) {
+          return remote.push(
                 ["refs/heads/" + branch + ":refs/heads/" + branch],
                 {
                   callbacks: {
@@ -408,14 +408,16 @@ function pushToRemote() {
                   }
                 }
               );
-            })
-            .then(function () {
-              CommitButNoPush = 0;
-              window.onbeforeunload = Confirmed;
-              console.log("Push successful");
-              updateModalText("Push successful");
-              refreshAll(repo);
-            });
+        }).then(function() {
+          CommitButNoPush = 0;
+          window.onbeforeunload = Confirmed;
+          console.log("Push successful");
+          updateModalText("Push successful");
+          refreshAll(repo);
+        }).catch(function(err) {
+          console.log(err);
+          updateModalText("Push Failed : "+err.message);
+          });            
         });
     });
 }

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -347,26 +347,20 @@ function pullFromRemote() {
           }
         }
       });
-    })
     // Now that we're finished fetching, go ahead and merge our local branch
     // with the new one
-    .then(function () {
+    }).then(function () {
       return Git.Reference.nameToId(repository, "refs/remotes/origin/" + branch);
-    })
-    .then(function (oid) {
+    }).then(function (oid) {
       console.log("Looking up commit with id " + oid + " in all repositories");
       return Git.AnnotatedCommit.lookup(repository, oid);
-    }, function (err) {
-      console.log("fetching all remgit.ts, line 251, cannot find repository with old id" + err);
-    })
-    .then(function (annotated) {
+    }).then(function (annotated) {
       console.log("merging " + annotated + "with local forcefully");
       Git.Merge.merge(repository, annotated, null, {
         checkoutStrategy: Git.Checkout.STRATEGY.FORCE,
       });
       theirCommit = annotated;
-    })
-    .then(function () {
+    }).then(function () {
       let conflicsExist = false;
       let tid = "";
       if (readFile.exists(repoFullPath + "/.git/MERGE_MSG")) {
@@ -384,7 +378,11 @@ function pullFromRemote() {
         updateModalText("Successfully pulled from remote branch " + branch + ", and your repo is up to date now!");
         refreshAll(repository);
       }
-    });
+    }).catch(function(err) {
+      console.log(err);
+      updateModalText("Pull Failed : "+err.message);
+    }); 
+    
 }
 
 function pushToRemote() {


### PR DESCRIPTION
Solves Issue 71: pulling or pushing the 2nd time crashes the application. It looks like GitHub no longer let you use the same credentials object for different request requiring authentication. And hence we are creating and using a new object every time.

Solves Issue 72: in case of error occur during pull or push it shows that error message to the user. there was no catch in the process. (there was on in pull but at the wrong place) .

Solves new issue: errors during a pull cause the application to crash. for example, pull when there is no internet will crash the application with low-level assertion fail error. this issue is considered part of issue 72.

Note: no custom messages are created. the messages from the server are directly shown to the users.