### PR TITLE
ISSUE#105: Allow user to refresh commit graph when detects local repo changes

### DIFF
--- a/app/components/graphPanel/graph.panel.component.html
+++ b/app/components/graphPanel/graph.panel.component.html
@@ -1,8 +1,9 @@
 <div class="graph-panel" id="graph-panel">
   <!-- auto-detection box on commit graph -->
+  <button id="refresh-button" type="button" class="btn btn-info refresh-graph-btn" (click)="refreshGraph()">Refresh Graph</button>
   <div id="refresh-graph-alert" class="alert alert-warning" role="alert" tabindex="-1">
     Commit graph changes detected!
-    <button id="refresh-graph" type="button" class="btn btn-warning" (click)="refreshGraph()">Refresh Graph</button>
+    <button type="button" class="btn btn-warning refresh-graph-btn" (click)="refreshGraph()">Refresh Graph</button>
   </div>
 
   <div class="network" id="my-network">

--- a/app/components/graphPanel/graph.panel.component.html
+++ b/app/components/graphPanel/graph.panel.component.html
@@ -1,4 +1,10 @@
 <div class="graph-panel" id="graph-panel">
+  <!-- auto-detection box on commit graph -->
+  <div id="refresh-graph-alert" class="alert alert-warning" role="alert" tabindex="-1">
+    Commit graph changes detected!
+    <button id="refresh-graph" type="button" class="btn btn-warning" (click)="refreshGraph()">Refresh Graph</button>
+  </div>
+
   <div class="network" id="my-network">
   </div>
 

--- a/app/components/graphPanel/graph.panel.component.ts
+++ b/app/components/graphPanel/graph.panel.component.ts
@@ -59,7 +59,7 @@ export class GraphPanelComponent {
     createTag(tagName, getSelectedCommit(), pushTag, tagMessage);
   }
 
-  // Initializes  the create tag modal. Should be called before displaying the modal.
+  // Initializes the create tag modal. Should be called before displaying the modal.
   setCreateTagModal() {
     $("#createTagModalCreateButton")[0].disabled = false;
 
@@ -72,9 +72,15 @@ export class GraphPanelComponent {
     let inputPushTag = $("#inputPushTag")[0];
     inputPushTag.checked = inputPushTag.defaultChecked;
     inputPushTag.disabled = signed ? false : true;
-    inputPushTag.title = signed ? "" : "Must be signed in to push tags"
+    inputPushTag.title = signed ? "" : "Must be signed in to push tags";
 
     let createTagError = $("#createTagError")[0];
     createTagError.innerHTML = "";
+  }
+
+  refreshGraph(): void {
+    $("#refresh-graph-alert").hide();
+    drawGraph();
+    updateModalText("Graph successfully refreshed");
   }
 }

--- a/app/components/graphPanel/graph.panel.component.ts
+++ b/app/components/graphPanel/graph.panel.component.ts
@@ -80,6 +80,7 @@ export class GraphPanelComponent {
 
   refreshGraph(): void {
     $("#refresh-graph-alert").hide();
+    $("#refresh-button").show();
     drawGraph();
     updateModalText("Graph successfully refreshed");
   }

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -20,6 +20,7 @@ let commitToRevert = 0;
 let commitHead = 0;
 let commitID = 0;
 let lastCommitLength;
+let refreshAllFlag = false;
 
 
 
@@ -268,7 +269,12 @@ function checkCommitChange() {
           if (typeof lastCommitLength !== "undefined" && lastCommitLength !== commits.length) {
             console.log("commit graph changes detected");
             // show refresh graph alert
-            $("#refresh-graph-alert").show();
+            if (!refreshAllFlag) {
+              $("#refresh-graph-alert").show();
+              $("#refresh-button").hide();
+            }
+
+            refreshAllFlag = false;
           }
 
           lastCommitLength = commits.length;

--- a/app/misc/graphing.ts
+++ b/app/misc/graphing.ts
@@ -475,6 +475,7 @@ function makeAbsNode(c, column: number) {
     let email = stringer.split("%")[1];
     let flag = true;
     let count = 1;
+    let nodeId;
     if (c.parents().length === 1) {
         let cp = c.parents()[0].toString();
         for (let i = 0; i < abstractList.length; i++) {
@@ -484,9 +485,40 @@ function makeAbsNode(c, column: number) {
                 abstractList[i]['count'] += 1;
                 count = abstractList[i]['count'];
                 abstractList[i]['sha'].push(c.toString());
-                abNodes.update({id: i+1, title: "Author: " + name + "<br>" + "Number of Commits: " + count});
+                nodeId = i+1;
+                abNodes.update({id: nodeId, title: "Author: " + name + "<br>" + "Number of Commits: " + count});
                 break;
             }
+        }
+    }
+
+    // Initializing viewable tags in second zoom graph level
+    if (c.toString() in tags) {
+        for (let i = 0; i < tags[c.toString()].length; i++) {
+            let tagName = tags[c.toString()][i];
+            let tp = tagName.name().split("/");
+            let shortTagName = tp[tp.length - 1];
+            console.log(shortTagName + " tag: " + tagName.isHead().toString());
+            if (tagName.isHead()) {
+                shortTagName = "*" + shortTagName;
+            }
+            let bsnodeId = generateUniqueNumber();
+            abNodes.add({
+                id: bsnodeId,
+                shape: "ellipse",
+                // color: "teal",
+                title: tagName, // hover text
+                label: shortTagName, // shown under/in shape
+                physics: false,
+                fixed: false,
+                x: (column - 0.6 * (i + 1)) * tagSpacingX,
+                y: (nodeId - 0.3) * tagSpacingY,
+            });
+
+            abEdges.add({
+                from: bsnodeId,
+                to: nodeId
+            });
         }
     }
 
@@ -528,36 +560,6 @@ function makeAbsNode(c, column: number) {
                     x: (column - 0.6 * (i + 1)) * spacingX,
                     y: (id - 0.3) * spacingY,
                     nodeType: NodeType.Branch
-                });
-
-                abEdges.add({
-                    from: bsnodeId,
-                    to: id
-                });
-            }
-        }
-
-        // Initializing viewable tags in second zoom graph level
-        if (c.toString() in tags) {
-            for (let i = 0; i < tags[c.toString()].length; i++) {
-                let tagName = tags[c.toString()][i];
-                let tp = tagName.name().split("/");
-                let shortTagName = tp[tp.length - 1];
-                console.log(shortTagName + " tag: " + tagName.isHead().toString());
-                if (tagName.isHead()) {
-                    shortTagName = "*" + shortTagName;
-                }
-                let bsnodeId = generateUniqueNumber();
-                abNodes.add({
-                    id: bsnodeId,
-                    shape: "ellipse",
-                    // color: "teal",
-                    title: tagName, // hover text
-                    label: shortTagName, // shown under/in shape
-                    physics: false,
-                    fixed: false,
-                    x: (column - 0.6 * (i + 1)) * tagSpacingX,
-                    y: (id - 0.3) * tagSpacingY,
                 });
 
                 abEdges.add({

--- a/app/misc/graphing.ts
+++ b/app/misc/graphing.ts
@@ -492,6 +492,38 @@ function makeAbsNode(c, column: number) {
         }
     }
 
+    if (flag) {
+        nodeId = absNodeId++;
+        let title = "Author: " + name + "<br>" + "Number of Commits: " + count;
+
+        abNodes.add({
+            id: nodeId,
+            shape: "circularImage",
+            title: title,
+            image: img4User(name),
+            physics: false,
+            fixed: false,
+            x: (column - 1) * spacingX,
+            y: (nodeId - 1) * spacingY,
+            author: c.author(),
+            nodeType: NodeType.Abstract
+        });
+
+        let shaList = [];
+        shaList.push(c.toString());
+
+        abstractList.push({
+            sha: shaList,
+            id: nodeId,
+            time: c.timeMs(),
+            column: column,
+            email: email,
+            reference: reference,
+            parents: c.parents(),
+            count: 1,
+        });
+    }
+
     // link the branch to updated absNode
     if (c.toString() in bname) {
         for (let i = 0; i < bname[c.toString()].length; i++) {
@@ -550,97 +582,6 @@ function makeAbsNode(c, column: number) {
                 to: nodeId
             });
         }
-    }
-
-    if (flag) {
-        let id = absNodeId++;
-        let title = "Author: " + name + "<br>" + "Number of Commits: " + count;
-
-        abNodes.add({
-            id: id,
-            shape: "circularImage",
-            title: title,
-            image: img4User(name),
-            physics: false,
-            fixed: false,
-            x: (column - 1) * spacingX,
-            y: (id - 1) * spacingY,
-            author: c.author(),
-            nodeType: NodeType.Abstract
-        });
-
-        if (c.toString() in bname) {
-            for (let i = 0; i < bname[c.toString()].length; i++) {
-                let branchName = bname[c.toString()][i];
-                let bp = branchName.name().split("/");
-                let shortName = bp[bp.length - 1];
-                console.log(shortName + " sub-branch: " + branchName.isHead().toString());
-                if (branchName.isHead()) {
-                    shortName = "*" + shortName;
-                }
-                let bsnodeId = generateUniqueNumber();
-                abNodes.add({
-                    id: bsnodeId,
-                    shape: "box",
-                    title: branchName,
-                    label: shortName,
-                    physics: false,
-                    fixed: false,
-                    x: (column - 0.6 * (i + 1)) * spacingX,
-                    y: (id - 0.3) * spacingY,
-                    nodeType: NodeType.Branch
-                });
-
-                abEdges.add({
-                    from: bsnodeId,
-                    to: id
-                });
-            }
-        }
-
-        // Initializing viewable tags in second zoom graph level
-        if (c.toString() in tags) {
-            for (let i = 0; i < tags[c.toString()].length; i++) {
-                let tagName = tags[c.toString()][i];
-                let tp = tagName.name().split("/");
-                let shortTagName = tp[tp.length - 1];
-                console.log(shortTagName + " tag: " + tagName.isHead().toString());
-                if (tagName.isHead()) {
-                    shortTagName = "*" + shortTagName;
-                }
-                let bsnodeId = generateUniqueNumber();
-                abNodes.add({
-                    id: bsnodeId,
-                    shape: "ellipse",
-                    // color: "teal",
-                    title: tagName, // hover text
-                    label: shortTagName, // shown under/in shape
-                    physics: false,
-                    fixed: false,
-                    x: (column - 0.6 * (i + 1)) * tagSpacingX,
-                    y: (id - 0.3) * tagSpacingY,
-                });
-
-                abEdges.add({
-                    from: bsnodeId,
-                    to: id
-                });
-            }
-        }
-
-        let shaList = [];
-        shaList.push(c.toString());
-
-        abstractList.push({
-            sha: shaList,
-            id: id,
-            time: c.timeMs(),
-            column: column,
-            email: email,
-            reference: reference,
-            parents: c.parents(),
-            count: 1,
-        });
     }
 }
 

--- a/app/misc/graphing.ts
+++ b/app/misc/graphing.ts
@@ -492,7 +492,37 @@ function makeAbsNode(c, column: number) {
         }
     }
 
-    // Initializing viewable tags in second zoom graph level
+    // link the branch to updated absNode
+    if (c.toString() in bname) {
+        for (let i = 0; i < bname[c.toString()].length; i++) {
+            let branchName = bname[c.toString()][i];
+            let bp = branchName.name().split("/");
+            let shortName = bp[bp.length - 1];
+            console.log(shortName + " sub-branch: " + branchName.isHead().toString());
+            if (branchName.isHead()) {
+                shortName = "*" + shortName;
+            }
+            let bsnodeId = generateUniqueNumber();
+            abNodes.add({
+                id: bsnodeId,
+                shape: "box",
+                title: branchName,
+                label: shortName,
+                physics: false,
+                fixed: false,
+                x: (column - 0.6 * (i + 1)) * spacingX,
+                y: (nodeId - 0.3) * spacingY,
+                nodeType: NodeType.Branch
+            });
+
+            abEdges.add({
+                from: bsnodeId,
+                to: nodeId
+            });
+        }
+    }
+
+    // link the tag to updated absNode
     if (c.toString() in tags) {
         for (let i = 0; i < tags[c.toString()].length; i++) {
             let tagName = tags[c.toString()][i];
@@ -524,7 +554,6 @@ function makeAbsNode(c, column: number) {
 
     if (flag) {
         let id = absNodeId++;
-        let tagid = id + 1;
         let title = "Author: " + name + "<br>" + "Number of Commits: " + count;
 
         abNodes.add({
@@ -569,6 +598,36 @@ function makeAbsNode(c, column: number) {
             }
         }
 
+        // Initializing viewable tags in second zoom graph level
+        if (c.toString() in tags) {
+            for (let i = 0; i < tags[c.toString()].length; i++) {
+                let tagName = tags[c.toString()][i];
+                let tp = tagName.name().split("/");
+                let shortTagName = tp[tp.length - 1];
+                console.log(shortTagName + " tag: " + tagName.isHead().toString());
+                if (tagName.isHead()) {
+                    shortTagName = "*" + shortTagName;
+                }
+                let bsnodeId = generateUniqueNumber();
+                abNodes.add({
+                    id: bsnodeId,
+                    shape: "ellipse",
+                    // color: "teal",
+                    title: tagName, // hover text
+                    label: shortTagName, // shown under/in shape
+                    physics: false,
+                    fixed: false,
+                    x: (column - 0.6 * (i + 1)) * tagSpacingX,
+                    y: (id - 0.3) * tagSpacingY,
+                });
+
+                abEdges.add({
+                    from: bsnodeId,
+                    to: id
+                });
+            }
+        }
+
         let shaList = [];
         shaList.push(c.toString());
 
@@ -587,7 +646,6 @@ function makeAbsNode(c, column: number) {
 
 function makeNode(c, column: number) {
     let id = nodeId++;
-    let tagid = id + 1;
     let reference;
     let name = getName(c.author().toString());
     let stringer = c.author().toString().replace(/</, "%").replace(/>/, "%");
@@ -690,7 +748,6 @@ function makeNode(c, column: number) {
         reference: reference,
         branch: flag,
     });
-    // console.log("commit: "+ id + ", message: " + commitList[id-1]['id']); // + ", tags: " + tags[tagid]; ??
 }
 
 function makeEdge(sha: string, parentSha: string) {

--- a/app/misc/repo.ts
+++ b/app/misc/repo.ts
@@ -353,8 +353,9 @@ function refreshList(verbose) {
     let branch;
     bname = {};
     tags = {};
+    lastRefList = [];
 
-    //Get the current branch from the repo
+      //Get the current branch from the repo
     repository.getCurrentBranch()
       .then(function (reference) {
         //Get the simplified name from the branch

--- a/app/misc/repo.ts
+++ b/app/misc/repo.ts
@@ -280,6 +280,12 @@ function refreshList(verbose) {
 
           // detects changes, refresh the lists
           console.log("branch or tag changes detected... refreshing branch and tag list");
+
+          if (lastRefList.length !== 0) {
+            // show refresh graph alert
+            $("#refresh-graph-alert").show();
+          }
+
           bname = {};
           tags = {};
           clearBranchAndTagElement();

--- a/app/misc/repo.ts
+++ b/app/misc/repo.ts
@@ -365,9 +365,10 @@ function refreshList(verbose) {
           // detects changes, refresh the lists
           console.log("branch or tag changes detected... refreshing branch and tag list");
 
-          if (lastRefList.length !== 0) {
+          if (lastRefList.length !== 0 && !refreshAllFlag) {
             // show refresh graph alert
             $("#refresh-graph-alert").show();
+            $("#refresh-button").hide();
           }
 
           bname = {};
@@ -479,6 +480,8 @@ function refreshList(verbose) {
         // TODO: add a condition here to switch between tag and branch name string
         document.getElementById("branch-name").innerHTML = 'Branch: ' + '<span id="name-selected">' + "master" +'</span>' + '<span class="caret"></span>';
       });
+    // suppress commit detection alert
+    refreshAllFlag = true;
   }
 
   // Displaying branches in a dropdown menu

--- a/index.html
+++ b/index.html
@@ -93,15 +93,16 @@ document.addEventListener('DOMContentLoaded', function() {
 
   }, 2000);
 
-  // Update modified files on left file panel every X seconds
+  // group all monitors here, call every 3 seconds
   setInterval(function() {
+    // Update modified files on left file panel
     displayModifiedFiles();
+    // monitor changes on branch list and tag list
+    refreshList(false);
+    // check if there is any changes to either ref list or commits
+    checkCommitChange();
   }, 3000);
 
-  // monitor changes on branch list and tag list, 1 check per second
-  setInterval(function () {
-    refreshList(false);
-  }, 1000);
 }, false);
 
 

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -1110,8 +1110,12 @@ body .pull-request-panel {
 }
 
 /* commit graph refresh button style */
-#refresh-graph {
+.refresh-graph-btn {
   float: right;
+}
+
+#refresh-button {
+  margin: 10px 10px 0 0;
 }
 
 .btn {

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -1099,3 +1099,22 @@ body .pull-request-panel {
   font-size: larger;
   max-width: 70%;
 }
+
+/* commit graph change alert box style */
+#refresh-graph-alert {
+  margin-bottom: 0;
+  padding: 10px;
+  line-height: 34px;
+  font-weight: 600;
+  display: none;
+}
+
+/* commit graph refresh button style */
+#refresh-graph {
+  float: right;
+}
+
+.btn {
+  outline: none;
+}
+


### PR DESCRIPTION
Feature:
- Added a button to allow user refresh commit graph at any time.
- Commit graph can auto detects changes in number of commits in the repo and alert user.

Fix:
- This PR also fixed problem where when at second level zoom, tags and branches are missing in non-HEAD commit.

Design logic:
- From user's point of view, when commit graph detects any changes(whether new tag or branch has been created or new commits has been made), a yellow warning banner will show up with button to allow user to refresh the graph.
- How I achieved this: 1) periodic checks on tag and branch list changes and changes in number of commit current branch has. 2) once detects change, it pops up a banner to tell user that the commit graph is outdated and could be refreshed by pressing the refresh button.

How to test/review this feature:
1. open a repo
2. create or delete tag/branch/commit using command line tools, the refresh button will show up
3. click 'Refresh Graph' button to refresh the commit graph 

Existing problems:
- White node problem might appear after refresh the graph, this problem is under investigation in issue #101 and issue #29. 
- When new commits has been created in current branch, after refreshed the graph, the current branch tag still points to old HEAD commit instead of the new HEAD commit just created. This problem is not caused by this PR because the refresh button only uses existing `drawGraph()` function. I am not sure if this problem should stop me from creating this PR. However, if I have time I might investigate on this one. 