### PR TITLE
Feature 56 - delete a tag 

### DIFF
--- a/app/misc/repo.ts
+++ b/app/misc/repo.ts
@@ -609,27 +609,6 @@ function refreshList(verbose) {
     ul.appendChild(li);
   }
 
-  // deleting tags
-  function deleteTag() {
-
-    // remove taglist item
-    var tagName = name.getAttribute("id");
-    var tagNode = document.getElementById(tagName);
-    name.parentNode.removeChild(name);
-
-    let repo;
-    Git.Repository.open(repoFullPath)
-      .then(function(repoParam) {
-        repo = repoParam;
-      })
-      .then(function(){
-        return Git.Tag.delete(repo, tagName);
-      }
-    ).catch(function(msg) {
-      let errorMessage = "Error: " + msg.message;
-    });
-  }
-
   // Adding tags to branch dropdown menu
   function displayTag(name, id, onclick) {
 

--- a/app/misc/repo.ts
+++ b/app/misc/repo.ts
@@ -610,7 +610,7 @@ function refreshList(verbose) {
   }
 
   // deleting tags
-  function deleteTag(name) {
+  function deleteTag() {
 
     // remove taglist item
     var tagName = name.getAttribute("id");
@@ -630,11 +630,6 @@ function refreshList(verbose) {
     });
   }
 
-  function deleteTagModal() {
-    updateModalText("Double click to delete a tag");
-    $('a').attr('onclick', '')
-  }
-
   // Adding tags to branch dropdown menu
   function displayTag(name, id, onclick) {
 
@@ -642,17 +637,44 @@ function refreshList(verbose) {
     let tagList = document.getElementById(id);
     let li = document.createElement("li");
     let a = document.createElement("a");
+    let span = document.createElement("span");
+    let button = document.createElement("span");
 
     // set HTML attributes
     a.setAttribute("href", "#");
     a.setAttribute("class", "list-group-item tag-list-item");
     a.setAttribute("id", name);
-    a.setAttribute("onclick", onclick + ";event.stopPropagation();deleteTagModal();");
-    a.setAttribute("ondblclick", "deleteTag(" + name + ")");
+    a.setAttribute("onclick", onclick + ";event.stopPropagation();");
     li.setAttribute("role", "presentation");
+    span.setAttribute("class", "pull-right");
+    button.setAttribute("id", name);
+    button.setAttribute("class", "btn btn-danger");
+    button.innerHTML = "Delete";
 
+    // deleting a tag
+    button.onclick = (event) => {
+
+      // get name of tag from event
+      tagName = event.srcElement.getAttribute("id");
+
+      let repo;
+      Git.Repository.open(repoFullPath)
+        .then(function(repoParam) {
+          repo = repoParam;
+        })
+        .then(function(){
+          return Git.Tag.delete(repo, tagName);
+        }
+      ).catch(function(msg) {
+        let errorMessage = "Error: " + msg.message;
+      });
+    }
+
+    // create tag element in list
+    span.appendChild(button);
     a.appendChild(document.createTextNode(id));
     a.innerHTML = name;
+    a.appendChild(span);
     li.appendChild(a);
     tagList.appendChild(li);
   }

--- a/app/misc/repo.ts
+++ b/app/misc/repo.ts
@@ -609,10 +609,6 @@ function refreshList(verbose) {
     ul.appendChild(li);
   }
 
-  function getTagByIdRegex(tag, id, html) {
-    return new RegExp("<" + tag + "[^>]*id[\\s]?=[\\s]?['\"]" + id + "['\"][\\s\\S]*?<\/" + tag + ">").exec(html);
-  }
-
   // deleting tags
   function deleteTag(name) {
 
@@ -634,6 +630,11 @@ function refreshList(verbose) {
     });
   }
 
+  function deleteTagModal() {
+    updateModalText("Double click to delete a tag");
+    $('a').attr('onclick', '')
+  }
+
   // Adding tags to branch dropdown menu
   function displayTag(name, id, onclick) {
 
@@ -641,22 +642,17 @@ function refreshList(verbose) {
     let tagList = document.getElementById(id);
     let li = document.createElement("li");
     let a = document.createElement("a");
-    let button = document.createElement("button");
 
     // set HTML attributes
     a.setAttribute("href", "#");
-    a.setAttribute("class", "list-group-item");
+    a.setAttribute("class", "list-group-item tag-list-item");
     a.setAttribute("id", name);
-    a.setAttribute("onclick", onclick + ";event.stopPropagation()");
+    a.setAttribute("onclick", onclick + ";event.stopPropagation();deleteTagModal();");
+    a.setAttribute("ondblclick", "deleteTag(" + name + ")");
     li.setAttribute("role", "presentation");
-    button.setAttribute("class", "delete-tag-button");
-    button.setAttribute("class", "btn btn-outline-danger btn-lg");
-    button.setAttribute("type", "button");
-    button.setAttribute("onclick", "deleteTag(" + name + ")");
 
     a.appendChild(document.createTextNode(id));
     a.innerHTML = name;
-    a.appendChild(button);
     li.appendChild(a);
     tagList.appendChild(li);
   }

--- a/app/misc/repo.ts
+++ b/app/misc/repo.ts
@@ -609,24 +609,55 @@ function refreshList(verbose) {
     ul.appendChild(li);
   }
 
-// Adding tags to branch dropdown menu
+  function getTagByIdRegex(tag, id, html) {
+    return new RegExp("<" + tag + "[^>]*id[\\s]?=[\\s]?['\"]" + id + "['\"][\\s\\S]*?<\/" + tag + ">").exec(html);
+  }
+
+  // deleting tags
+  function deleteTag(name) {
+
+    // remove taglist item
+    var tagName = name.getAttribute("id");
+    var tagNode = document.getElementById(tagName);
+    name.parentNode.removeChild(name);
+
+    let repo;
+    Git.Repository.open(repoFullPath)
+      .then(function(repoParam) {
+        repo = repoParam;
+      })
+      .then(function(){
+        return Git.Tag.delete(repo, tagName);
+      }
+    ).catch(function(msg) {
+      let errorMessage = "Error: " + msg.message;
+    });
+  }
+
+  // Adding tags to branch dropdown menu
   function displayTag(name, id, onclick) {
+
+    // create HTML element for tag list dropdown
     let tagList = document.getElementById(id);
     let li = document.createElement("li");
     let a = document.createElement("a");
+    let button = document.createElement("button");
+
+    // set HTML attributes
     a.setAttribute("href", "#");
     a.setAttribute("class", "list-group-item");
     a.setAttribute("id", name);
     a.setAttribute("onclick", onclick + ";event.stopPropagation()");
     li.setAttribute("role", "presentation");
-    a.appendChild(document.createTextNode(name));
+    button.setAttribute("class", "delete-tag-button");
+    button.setAttribute("class", "btn btn-outline-danger btn-lg");
+    button.setAttribute("type", "button");
+    button.setAttribute("onclick", "deleteTag(" + name + ")");
+
+    a.appendChild(document.createTextNode(id));
     a.innerHTML = name;
+    a.appendChild(button);
     li.appendChild(a);
-
-    if (id === "tag-item-list") {
-      // TODO: tagging support - add delete button here
-    }
-
     tagList.appendChild(li);
   }
 

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -1100,7 +1100,7 @@ body .pull-request-panel {
   max-width: 70%;
 }
 
-.delete-tag-button {
-  position: relative;
-  right: 0; 
+.tag-list-item:hover {
+  color: red;
+  
 }

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -1086,10 +1086,10 @@ body .pull-request-panel {
   display: list-item;
 }
 
-.modal-body label { 
-  display: inline-block; 
-  width: 20%; 
-  text-align: left; 
+.modal-body label {
+  display: inline-block;
+  width: 20%;
+  text-align: left;
 }
 
 .modal-error {
@@ -1098,4 +1098,9 @@ body .pull-request-panel {
   color: red;
   font-size: larger;
   max-width: 70%;
+}
+
+.delete-tag-button {
+  position: relative;
+  right: 0; 
 }

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -1099,8 +1099,3 @@ body .pull-request-panel {
   font-size: larger;
   max-width: 70%;
 }
-
-.tag-list-item:hover {
-  color: red;
-  
-}


### PR DESCRIPTION
This feature allows you to delete a tag from the tag list. 

**Implementation** 
- The CSS for implementing a button within the list items for the tags was very ugly, so I implemented the ability to double click to delete tag. 
- Upon a single click, a modal pops up to let the user know that they can double click on a tag to delete it. After this first click, the modal doesn't appear anymore. 
- The changes in the tag list are reflected immediately but the graph is not updated. Issue #105 covers that scope. 

Note: there is a minor bug where you cannot delete tag names with periods in them. This is due to JS being unable to handle function passing of strings with periods in the name. I can open an issue for this for further investigation and am open to suggestions on how to fix it. 