### PR TITLE
Issue 102 - Fix Icon Text Alignment

### DIFF
--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -744,7 +744,7 @@ div.selected-commit-diff-panel button.close-button {
 .toolbar-Icons {
   text-align: center;
   cursor: pointer;
-  padding: 10px;
+  padding-top: 10px;
   margin: 0 auto;
   max-height: 65px;
   max-width: 55px;


### PR DESCRIPTION
Fixes issue #102  - navbar icon text was left aligned and then switched to center align on hover. Now always centered