### PR TITLE
Issue 31: GitHub profile pictures on nodes

### DIFF
--- a/app/misc/graphing.ts
+++ b/app/misc/graphing.ts
@@ -373,14 +373,18 @@ function makeBasicNode(c, column: number) {
     if (flag) {
         id = basicNodeId++;
         tagid = id + 1;
-
         let title = "Number of Commits: " + count;
         console.log(title);
+        let imageUrl;
+        imageForUser(name, email, function (pic) {
+            imageUrl = pic;
+        });
+
         bsNodes.add({
             id: id,
             shape: "circularImage",
             title: title,
-            image: imageForUser(name,'null'),   // TODO: actually pass in the email instead of 'null'
+            image: imageUrl,
             physics: false,
             fixed: false,
             x: (column - 1) * spacingX,
@@ -494,12 +498,16 @@ function makeAbsNode(c, column: number) {
         let id = absNodeId++;
         let tagid = id + 1;
         let title = "Author: " + name + "<br>" + "Number of Commits: " + count;
-
+        let imageUrl;
+        imageForUser(name, email, function (pic) {
+            imageUrl = pic;
+        });
+        
         abNodes.add({
             id: id,
             shape: "circularImage",
             title: title,
-            image: imageForUser(name,'null'),   // TODO: actually pass in the email instead of 'null'
+            image: imageUrl,
             physics: false,
             fixed: false,
             x: (column - 1) * spacingX,
@@ -604,11 +612,16 @@ function makeNode(c, column: number) {
     }
 
     let flag = false;
+    let imageUrl;
+    imageForUser(name, email, function (pic) {
+        imageUrl = pic;
+    });
+    
     nodes.add({
         id: id,
         shape: "circularImage",
         title: title,
-        image: imageForUser(name,'null'),   // TODO: actually pass in the email instead of 'null'
+        image: imageUrl,
         physics: false,
         fixed: false,
         x: (column - 1) * spacingX,

--- a/app/misc/graphing.ts
+++ b/app/misc/graphing.ts
@@ -350,6 +350,7 @@ function makeBasicNode(c, column: number) {
     let reference;
     let name = getName(c.author().toString());
     let stringer = c.author().toString().replace(/</, "%").replace(/>/, "%");
+    let email = stringer.split("%")[1];
     let flag = true;
     let count = 1;
     let id;

--- a/app/misc/graphing.ts
+++ b/app/misc/graphing.ts
@@ -377,22 +377,30 @@ function makeBasicNode(c, column: number) {
         let title = "Number of Commits: " + count;
         console.log(title);
         let imageUrl;
+        console.log(`imageForUser(): name=${name}, email=${email}`)
         imageForUser(name, email, function (pic) {
             imageUrl = pic;
-        });
 
-        bsNodes.add({
-            id: id,
-            shape: "circularImage",
-            title: title,
-            image: imageUrl,
-            physics: false,
-            fixed: false,
-            x: (column - 1) * spacingX,
-            y: (id - 1) * spacingY,
-            author: c.author(),
-            nodeType: NodeType.Basic
-        });
+            bsNodes.add({
+                id: id,
+                shape: "circularImage",
+                title: title,
+                image: imageUrl,
+                physics: false,
+                fixed: false,
+                x: (column - 1) * spacingX,
+                y: (id - 1) * spacingY,
+                author: c.author(),
+                nodeType: NodeType.Basic
+            });
+
+        });        
+        // TODO:
+        // if (typeof(imageUrl) === "undefined") {
+        //     imageUrl = getLetterIcon(name);
+        // }
+
+
 
         let shaList = [];
         shaList.push(c.toString());
@@ -500,22 +508,32 @@ function makeAbsNode(c, column: number) {
         let tagid = id + 1;
         let title = "Author: " + name + "<br>" + "Number of Commits: " + count;
         let imageUrl;
+        console.log(`imageForUser(): name=${name}, email=${email}`)
         imageForUser(name, email, function (pic) {
             imageUrl = pic;
+            
+            abNodes.add({
+                id: id,
+                shape: "circularImage",
+                title: title,
+                image: imageUrl,
+                physics: false,
+                fixed: false,
+                x: (column - 1) * spacingX,
+                y: (id - 1) * spacingY,
+                author: c.author(),
+                nodeType: NodeType.Abstract
+            });
+
         });
+
         
-        abNodes.add({
-            id: id,
-            shape: "circularImage",
-            title: title,
-            image: imageUrl,
-            physics: false,
-            fixed: false,
-            x: (column - 1) * spacingX,
-            y: (id - 1) * spacingY,
-            author: c.author(),
-            nodeType: NodeType.Abstract
-        });
+        // TODO:
+        // if (typeof(imageUrl) === "undefined") {
+        //     imageUrl = getLetterIcon(name);
+        // }
+
+
 
         if (c.toString() in bname) {
             for (let i = 0; i < bname[c.toString()].length; i++) {
@@ -614,23 +632,33 @@ function makeNode(c, column: number) {
 
     let flag = false;
     let imageUrl;
+    console.log(`imageForUser(): name=${name}, email=${email}`)
     imageForUser(name, email, function (pic) {
         imageUrl = pic;
+
+        nodes.add({
+            id: id,
+            shape: "circularImage",
+            title: title,
+            image: imageUrl,
+            physics: false,
+            fixed: false,
+            x: (column - 1) * spacingX,
+            y: (id - 1) * spacingY,
+            author: c.author(),
+            nodeType: NodeType.Node,
+            commitSha: c.sha()
+        });
+
     });
-    
-    nodes.add({
-        id: id,
-        shape: "circularImage",
-        title: title,
-        image: imageUrl,
-        physics: false,
-        fixed: false,
-        x: (column - 1) * spacingX,
-        y: (id - 1) * spacingY,
-        author: c.author(),
-        nodeType: NodeType.Node,
-        commitSha: c.sha()
-    });
+
+
+    // TODO:
+    // if (typeof(imageUrl) === "undefined") {
+    //     imageUrl = getLetterIcon(name);
+    // }
+
+
 
     if (c.toString() in bname) {
         for (let i = 0; i < bname[c.toString()].length; i++) {

--- a/app/misc/graphing.ts
+++ b/app/misc/graphing.ts
@@ -380,7 +380,7 @@ function makeBasicNode(c, column: number) {
             id: id,
             shape: "circularImage",
             title: title,
-            image: img4User(name),
+            image: imageForUser(name,'null'),   // TODO: actually pass in the email instead of 'null'
             physics: false,
             fixed: false,
             x: (column - 1) * spacingX,
@@ -499,7 +499,7 @@ function makeAbsNode(c, column: number) {
             id: id,
             shape: "circularImage",
             title: title,
-            image: img4User(name),
+            image: imageForUser(name,'null'),   // TODO: actually pass in the email instead of 'null'
             physics: false,
             fixed: false,
             x: (column - 1) * spacingX,
@@ -608,7 +608,7 @@ function makeNode(c, column: number) {
         id: id,
         shape: "circularImage",
         title: title,
-        image: img4User(name),
+        image: imageForUser(name,'null'),   // TODO: actually pass in the email instead of 'null'
         physics: false,
         fixed: false,
         x: (column - 1) * spacingX,

--- a/app/misc/graphing.ts
+++ b/app/misc/graphing.ts
@@ -396,11 +396,6 @@ function makeBasicNode(c, column: number) {
             });
 
         });        
-        // TODO:
-        // if (typeof(imageUrl) === "undefined") {
-        //     imageUrl = getLetterIcon(name);
-        // }
-
 
 
         let shaList = [];
@@ -529,13 +524,6 @@ function makeAbsNode(c, column: number) {
 
         });
 
-        
-        // TODO:
-        // if (typeof(imageUrl) === "undefined") {
-        //     imageUrl = getLetterIcon(name);
-        // }
-
-
 
         if (c.toString() in bname) {
             for (let i = 0; i < bname[c.toString()].length; i++) {
@@ -654,13 +642,6 @@ function makeNode(c, column: number) {
         });
 
     });
-
-
-    // TODO:
-    // if (typeof(imageUrl) === "undefined") {
-    //     imageUrl = getLetterIcon(name);
-    // }
-
 
 
     if (c.toString() in bname) {

--- a/app/misc/graphing.ts
+++ b/app/misc/graphing.ts
@@ -378,6 +378,7 @@ function makeBasicNode(c, column: number) {
         console.log(title);
         let imageUrl;
         
+        // Get the image URL, then create and add the node for the commmit
         imageForUser(name, email, function (pic) {
             imageUrl = pic;
 
@@ -509,6 +510,7 @@ function makeAbsNode(c, column: number) {
         let title = "Author: " + name + "<br>" + "Number of Commits: " + count;
         let imageUrl;
         
+        // Get the image URL, then create and add the node for the commmit
         imageForUser(name, email, function (pic) {
             imageUrl = pic;
             
@@ -633,6 +635,7 @@ function makeNode(c, column: number) {
     let flag = false;
     let imageUrl;
     
+    // Get the image URL, then create and add the node for the commmit
     imageForUser(name, email, function (pic) {
         imageUrl = pic;
 

--- a/app/misc/graphing.ts
+++ b/app/misc/graphing.ts
@@ -377,7 +377,7 @@ function makeBasicNode(c, column: number) {
         let title = "Number of Commits: " + count;
         console.log(title);
         let imageUrl;
-        console.log(`imageForUser(): name=${name}, email=${email}`)
+        
         imageForUser(name, email, function (pic) {
             imageUrl = pic;
 
@@ -508,7 +508,7 @@ function makeAbsNode(c, column: number) {
         let tagid = id + 1;
         let title = "Author: " + name + "<br>" + "Number of Commits: " + count;
         let imageUrl;
-        console.log(`imageForUser(): name=${name}, email=${email}`)
+        
         imageForUser(name, email, function (pic) {
             imageUrl = pic;
             
@@ -632,7 +632,7 @@ function makeNode(c, column: number) {
 
     let flag = false;
     let imageUrl;
-    console.log(`imageForUser(): name=${name}, email=${email}`)
+    
     imageForUser(name, email, function (pic) {
         imageUrl = pic;
 

--- a/app/misc/images.ts
+++ b/app/misc/images.ts
@@ -52,25 +52,4 @@ function imageForUser(name: string, email: string, callback) {
     pic = getLetterIcon(name);
   }  
   callback(pic);
-  // githubAvatarUrl(username, function(err,avatarURL){
-  //   if(!err && !email.includes('@users.noreply.github.com')) {
-  //     console.log(`avatar url: ${avatarURL}`);
-  //     pic = avatarURL;
-  //   } 
-  //   // fallback to letter icons if the email isn't a GitHub noreply one
-  //   else {
-  //     let first = name.trim().charAt(0).toUpperCase();
-  //     pic =  "node_modules/material-letter-icons/dist/png/" + first + ".png";
-  //   }
-    
-  // });
-
-  // if (images[email] === undefined) {
-  //   images[email] = "assets/img/starwars/" + imageFiles[imageCount];
-  //   imageCount++;
-  //   if (imageCount >= imageFiles.length) {
-  //     imageCount = 0;
-  //   }
-  // }
-  // return images[email];
 }

--- a/app/misc/images.ts
+++ b/app/misc/images.ts
@@ -46,6 +46,7 @@ function imageForUser(name: string, email: string, callback) {
     else {
       // github-avatar-url insists on having an API token, 
       // but since we're don't need it for public info, we'll instead use octonode to avoid having said token.
+      // That being said, if you've hit the rate limit, just supply the token below; i.e. gh.client('token')
       let client = gh.client();
       
       client.get(`/users/${username}`, {}, function (err, status, body, headers) {
@@ -53,8 +54,10 @@ function imageForUser(name: string, email: string, callback) {
           pic = body.avatar_url;
           images[username] = pic;   // add to cache
         }        
-        else {    // fallback to letter icons if API request failed
+        else {
+          console.log(`GitHub API: ${err}`);
           console.log("GitHub API request failed; using letter icons instead");
+
           pic = getLetterIcon(name);
         }        
         callback(pic);

--- a/app/misc/images.ts
+++ b/app/misc/images.ts
@@ -3,31 +3,67 @@ let images = {};
 let imageFiles = ["jarjar.jpg", "yoda.png", "obiwan.jpg"];
 let imageCount = 0;
 let githubAvatarUrl = require('github-avatar-url');
+let gh = require('octonode');
+
+/**
+ * Helper function for getting the letter icon for a given author.
+ * 
+ * @param name Name of the commit's contributor
+ * @returns filepath for the given person's first initial
+ */
+function getLetterIcon(name: string) {
+  let first = name.trim().charAt(0).toUpperCase();
+  return "node_modules/material-letter-icons/dist/png/" + first + ".png";
+}
 
 function getName(author: string) {
   let name = author.split("<")[0];
   return name;
 }
 
-function img4User(name:string) {
-  let pic;
-  let first = name.trim().charAt(0).toUpperCase();
-  pic =  "node_modules/material-letter-icons/dist/png/" + first + ".png";
-  return pic;
+function img4User(name:string) {  
+  return getLetterIcon(name);
 }
 
+// seems like this function was implemented as scaffolding for the profile pic feature.
 function imageForUser(name: string, email: string, callback) {
-  let pic;
-  githubAvatarUrl(name, function(err,avatarURL){
-    if(!err) {
-      console.log("avatar url: avatarURL");
-      pic = avatarURL;
-    } else {
-      let first = name.trim().charAt(0).toUpperCase();
-      pic =  "node_modules/material-letter-icons/dist/png/" + first + ".png";
-    }
-    callback(pic);
-  });
+  
+  let pic;  
+  
+  if (email.includes('@users.noreply.github.com')) {
+    
+    // Extract GitHub username from noreply email (<number>+<username>@users.noreply.github.com)
+    // This won't work for users that are NOT hiding their email in the GitHub settings.
+    // See https://help.github.com/en/articles/about-commit-email-addresses for more info.
+    let username = email.replace('@users.noreply.github.com','').replace(/^(\d){7}\+/,'');
+
+    // github-avatar-url insists on having an API token, 
+    // but since we're don't need it for public info, we'll instead use octonode to avoid having said token.
+    let client = gh.client();
+    client.get(`/users/${username}`, {}, function (err, status, body, headers) {
+      if (!err)
+        pic = body.avatar_url;
+      else
+        pic = getLetterIcon(name);
+    });
+  }
+  // fallback to letter icons if the email isn't a GitHub noreply one
+  else {
+    pic = getLetterIcon(name);
+  }  
+  callback(pic);
+  // githubAvatarUrl(username, function(err,avatarURL){
+  //   if(!err && !email.includes('@users.noreply.github.com')) {
+  //     console.log(`avatar url: ${avatarURL}`);
+  //     pic = avatarURL;
+  //   } 
+  //   // fallback to letter icons if the email isn't a GitHub noreply one
+  //   else {
+  //     let first = name.trim().charAt(0).toUpperCase();
+  //     pic =  "node_modules/material-letter-icons/dist/png/" + first + ".png";
+  //   }
+    
+  // });
 
   // if (images[email] === undefined) {
   //   images[email] = "assets/img/starwars/" + imageFiles[imageCount];

--- a/app/misc/images.ts
+++ b/app/misc/images.ts
@@ -1,17 +1,13 @@
-// cache for profile pictures
-let images = {};
-
-// let imageFiles = ["dog1.jpg", "dog2.jpg", "dog3.jpg", "dog4.jpg", "dog5.jpg"];
-let imageFiles = ["jarjar.jpg", "yoda.png", "obiwan.jpg"];
-let imageCount = 0;
-let githubAvatarUrl = require('github-avatar-url');
 let gh = require('octonode');
+
+// local cache for profile picture URLs
+let images = {};
 
 /**
  * Helper function for getting the letter icon for a given author.
  * 
- * @param name Name of the commit's contributor
- * @returns filepath for the given person's first initial
+ * @param name Name of the commit's author
+ * @returns filepath for the picture containing the author's first initial
  */
 function getLetterIcon(name: string) {
   let first = name.trim().charAt(0).toUpperCase();
@@ -23,13 +19,13 @@ function getName(author: string) {
   return name;
 }
 
-// seems like this function was meant to retrieve a profile pic for the nodes
-// TODO: no longer used, remove
+// No longer in use, but keeping it here in case of any backward-compatibility 
+// issues on other VisualGit branches.
 function img4User(name:string) {  
   return getLetterIcon(name);
 }
 
-// seems like this function was meant to retrieve a profile pic for the commit popup
+/** Retreives the URL for the given author's GitHub profile picture.*/
 function imageForUser(name: string, email: string, callback) {
   
   let pic;  
@@ -50,12 +46,13 @@ function imageForUser(name: string, email: string, callback) {
       // github-avatar-url insists on having an API token, 
       // but since we're don't need it for public info, we'll instead use octonode to avoid having said token.
       let client = gh.client();
+      
       client.get(`/users/${username}`, {}, function (err, status, body, headers) {
         if (!err) {
           pic = body.avatar_url;
           images[username] = pic;   // add to cache
-        }
-        else {
+        }        
+        else {    // fallback to letter icons if API request failed
           pic = getLetterIcon(name);
         }        
         callback(pic);

--- a/app/misc/images.ts
+++ b/app/misc/images.ts
@@ -19,8 +19,8 @@ function getName(author: string) {
   return name;
 }
 
-// No longer in use, but keeping it here in case of any backward-compatibility 
-// issues on other VisualGit branches.
+// No longer in use, but keeping it here in case of any potential 
+// backward-compatibility issues on other VisualGit branches.
 function img4User(name:string) {  
   return getLetterIcon(name);
 }
@@ -50,9 +50,10 @@ function imageForUser(name: string, email: string, callback) {
       let client = gh.client();
       
       client.get(`/users/${username}`, {}, function (err, status, body, headers) {
-        if (!err) {
+        if (!err) {          
           pic = body.avatar_url;
           images[username] = pic;   // add to cache
+          console.log(`GitHub API: ${pic}`)
         }        
         else {
           console.log(`GitHub API: ${err}`);

--- a/app/misc/images.ts
+++ b/app/misc/images.ts
@@ -21,11 +21,12 @@ function getName(author: string) {
   return name;
 }
 
+// seems like this function was meant to retrieve a profile pic for the nodes
 function img4User(name:string) {  
   return getLetterIcon(name);
 }
 
-// seems like this function was implemented as scaffolding for the profile pic feature.
+// seems like this function was meant to retrieve a profile pic for the commit popup
 function imageForUser(name: string, email: string, callback) {
   
   let pic;  
@@ -41,15 +42,18 @@ function imageForUser(name: string, email: string, callback) {
     // but since we're don't need it for public info, we'll instead use octonode to avoid having said token.
     let client = gh.client();
     client.get(`/users/${username}`, {}, function (err, status, body, headers) {
-      if (!err)
+      if (!err) {
         pic = body.avatar_url;
-      else
+      }
+      else {
         pic = getLetterIcon(name);
+      }
+      callback(pic);
     });
   }
   // fallback to letter icons if the email isn't a GitHub noreply one
   else {
     pic = getLetterIcon(name);
+    callback(pic);
   }  
-  callback(pic);
 }

--- a/app/misc/images.ts
+++ b/app/misc/images.ts
@@ -35,7 +35,7 @@ function imageForUser(name: string, email: string, callback) {
     // Extract GitHub username from noreply email (<number>+<username>@users.noreply.github.com)
     // This won't work for users that are NOT hiding their email in the GitHub settings.
     // See https://help.github.com/en/articles/about-commit-email-addresses for more info.
-    let username = email.replace('@users.noreply.github.com','').replace(/^(\d){7}\+/,'');
+    let username = email.replace('@users.noreply.github.com','').replace(/^(\d){4,}\+/,'');
     
     // try the local cache first
     pic = images[username];

--- a/app/misc/images.ts
+++ b/app/misc/images.ts
@@ -1,4 +1,6 @@
+// cache for profile pictures
 let images = {};
+
 // let imageFiles = ["dog1.jpg", "dog2.jpg", "dog3.jpg", "dog4.jpg", "dog5.jpg"];
 let imageFiles = ["jarjar.jpg", "yoda.png", "obiwan.jpg"];
 let imageCount = 0;
@@ -22,6 +24,7 @@ function getName(author: string) {
 }
 
 // seems like this function was meant to retrieve a profile pic for the nodes
+// TODO: no longer used, remove
 function img4User(name:string) {  
   return getLetterIcon(name);
 }
@@ -38,26 +41,30 @@ function imageForUser(name: string, email: string, callback) {
     // See https://help.github.com/en/articles/about-commit-email-addresses for more info.
     let username = email.replace('@users.noreply.github.com','').replace(/^(\d){7}\+/,'');
 
-    // github-avatar-url insists on having an API token, 
-    // but since we're don't need it for public info, we'll instead use octonode to avoid having said token.
-    let client = gh.client();
-    client.get(`/users/${username}`, {}, function (err, status, body, headers) {
-      if (!err) {
-        pic = body.avatar_url;
-      }
-      else {
-        pic = getLetterIcon(name);
-      }
-      if (typeof(callback) !== "undefined")
+    // try the local cache first
+    pic = images[username];
+    if (typeof(pic) !== "undefined") {
+      callback(pic);
+    }
+    else {
+      // github-avatar-url insists on having an API token, 
+      // but since we're don't need it for public info, we'll instead use octonode to avoid having said token.
+      let client = gh.client();
+      client.get(`/users/${username}`, {}, function (err, status, body, headers) {
+        if (!err) {
+          pic = body.avatar_url;
+          images[username] = pic;   // add to cache
+        }
+        else {
+          pic = getLetterIcon(name);
+        }        
         callback(pic);
-    });
+      });
+    }
   }
   // fallback to letter icons if the email isn't a GitHub noreply one
   else {
     pic = getLetterIcon(name);
-    if (typeof(callback) !== "undefined")
-      callback(pic);
+    callback(pic);
   }
-  if (typeof(callback) === "undefined")
-    return pic;  
 }

--- a/app/misc/images.ts
+++ b/app/misc/images.ts
@@ -48,12 +48,16 @@ function imageForUser(name: string, email: string, callback) {
       else {
         pic = getLetterIcon(name);
       }
-      callback(pic);
+      if (typeof(callback) !== "undefined")
+        callback(pic);
     });
   }
   // fallback to letter icons if the email isn't a GitHub noreply one
   else {
     pic = getLetterIcon(name);
-    callback(pic);
-  }  
+    if (typeof(callback) !== "undefined")
+      callback(pic);
+  }
+  if (typeof(callback) === "undefined")
+    return pic;  
 }

--- a/app/misc/images.ts
+++ b/app/misc/images.ts
@@ -36,10 +36,11 @@ function imageForUser(name: string, email: string, callback) {
     // This won't work for users that are NOT hiding their email in the GitHub settings.
     // See https://help.github.com/en/articles/about-commit-email-addresses for more info.
     let username = email.replace('@users.noreply.github.com','').replace(/^(\d){7}\+/,'');
-
+    
     // try the local cache first
     pic = images[username];
     if (typeof(pic) !== "undefined") {
+      console.log(`Cached image URL: ${pic}`)
       callback(pic);
     }
     else {
@@ -53,6 +54,7 @@ function imageForUser(name: string, email: string, callback) {
           images[username] = pic;   // add to cache
         }        
         else {    // fallback to letter icons if API request failed
+          console.log("GitHub API request failed; using letter icons instead");
           pic = getLetterIcon(name);
         }        
         callback(pic);
@@ -62,6 +64,7 @@ function imageForUser(name: string, email: string, callback) {
   // fallback to letter icons if the email isn't a GitHub noreply one
   else {
     pic = getLetterIcon(name);
+    console.log("No GitHub username detected; using letter icons instead");
     callback(pic);
   }
 }


### PR DESCRIPTION
This PR implements #31. 

In addition, GitHub profile pictures are now also available in the popup that appears when clicking on a node:

![commit_popup](https://user-images.githubusercontent.com/6787487/59317436-bbb97080-8c77-11e9-96d8-58108e486933.png)

In order to retrieve a user's profile picture through the GitHub API, the username is required. However, because usernames are a GitHub concept - Git works with full names and emails, as supplied via `git config user.name` and `user.email` - **GitHub usernames are scraped from `@users.noreply.github.com` emails if available**. Consequently, profile pictures are unavailable for users that did not hide their email in their GitHub settings and set their Git `user.email` to their `noreply` email ([more info here](https://help.github.com/en/articles/about-commit-email-addresses)).

Letter icons will continue to be used if a profile picture is unavailable.

There does not appear to be a way around this, as a Git repository simply does not contain the needed info required by the GitHub API. However, the existence of other Git GUIs (e.g. GitKraken) seems to prove otherwise. More investigation on this will be needed.

As well, some refactoring of `misc/images.ts` was also done: 
 * `img4User()` was rolled into `imageForUser()` 
    * `img4User()` is no longer used in this branch, but I've kept it in case anyone else is
 * Retrieval of letter-icon images was moved into a helper function
 * Existing unused/commented-out code was also removed

`misc/graphing.ts` was also slightly modified to accommodate the change to `imageForUser()` (in particular, the use of callbacks).