### PR TITLE
updated the git signatures to the user who is logged in instead of th…

### DIFF
--- a/app/misc/authenticate.ts
+++ b/app/misc/authenticate.ts
@@ -537,7 +537,10 @@ function getUsername(){
 }
 
 // Get a git signature for the account that is logged in.
-function getSignature(){
+function getSignature(repository){
+  // If the user has deffered loggin in, use the default signature
+  if (!account)
+    return repository.defaultSignature();
   // Set email to the email in account object
   var email = account.email;
   // If the email is null, change it to <uesrname>@users.noreply.github.com

--- a/app/misc/authenticate.ts
+++ b/app/misc/authenticate.ts
@@ -535,3 +535,14 @@ function getUsername(){
   // Return the users username
   return account.login;
 }
+
+// Get a git signature for the account that is logged in.
+function getSignature(){
+  // Set email to the email in account object
+  var email = account.email;
+  // If the email is null, change it to <uesrname>@users.noreply.github.com
+  if (!email)
+    email = account.login + '@users.noreply.github.com';
+  // Return the signature
+  return Git.Signature.now(account.login, email);
+}

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -184,7 +184,7 @@ function addAndCommit() {
       console.log("Verifying account");
       let sign;
 
-      sign = repository.defaultSignature();
+      sign = getSignature();
 
       commitMessage = document.getElementById('commit-message-input').value;
       console.log("Signature to be put on commit: " + sign.toString());
@@ -515,7 +515,7 @@ function createBranch() {
               branchName,
               commit,
               0,
-              repo.defaultSignature(),
+              getSignature(),
               "Created new-branch on HEAD");
           }, function (err) {
             console.log("git.ts, line 337, error occurred while trying to create a new branch " + err);
@@ -659,7 +659,7 @@ function mergeLocalBranches(element) {
       console.log("branch to merge to: " + toBranch.name());
       return repos.mergeBranches(toBranch,
         fromBranch,
-        repos.defaultSignature(),
+        getSignature(),
         Git.Merge.PREFERENCE.NONE,
         null);
     })
@@ -693,7 +693,7 @@ function createTag(tagName: string, commitSha: string, pushTag: boolean, message
       if (message == undefined) {
         return Git.Tag.createLightweight(repo, tagName, commit, 0);
       } else {
-        return Git.Tag.create(repo, tagName, commit, repo.defaultSignature(), message, 0);
+        return Git.Tag.create(repo, tagName, commit, getSignature(), message, 0);
       }
     })
     .then(function(tagOid){
@@ -918,7 +918,7 @@ function stashChanges() {
       // show the command to the user
       addCommand(cmdStr);
 
-      Git.Stash.save(repo, repo.defaultSignature(), stashMessage, flags)
+      Git.Stash.save(repo, getSignature(), stashMessage, flags)
         .then(function(oid) {
           // error for testing purposes
           //throw new Error('test error2');

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -184,7 +184,7 @@ function addAndCommit() {
       console.log("Verifying account");
       let sign;
 
-      sign = getSignature();
+      sign = getSignature(repository);
 
       commitMessage = document.getElementById('commit-message-input').value;
       console.log("Signature to be put on commit: " + sign.toString());
@@ -515,7 +515,7 @@ function createBranch() {
               branchName,
               commit,
               0,
-              getSignature(),
+              getSignature(repo),
               "Created new-branch on HEAD");
           }, function (err) {
             console.log("git.ts, line 337, error occurred while trying to create a new branch " + err);
@@ -659,7 +659,7 @@ function mergeLocalBranches(element) {
       console.log("branch to merge to: " + toBranch.name());
       return repos.mergeBranches(toBranch,
         fromBranch,
-        getSignature(),
+        getSignature(repos),
         Git.Merge.PREFERENCE.NONE,
         null);
     })
@@ -693,7 +693,7 @@ function createTag(tagName: string, commitSha: string, pushTag: boolean, message
       if (message == undefined) {
         return Git.Tag.createLightweight(repo, tagName, commit, 0);
       } else {
-        return Git.Tag.create(repo, tagName, commit, getSignature(), message, 0);
+        return Git.Tag.create(repo, tagName, commit, getSignature(repo), message, 0);
       }
     })
     .then(function(tagOid){
@@ -918,7 +918,7 @@ function stashChanges() {
       // show the command to the user
       addCommand(cmdStr);
 
-      Git.Stash.save(repo, getSignature(), stashMessage, flags)
+      Git.Stash.save(repo, getSignature(repo), stashMessage, flags)
         .then(function(oid) {
           // error for testing purposes
           //throw new Error('test error2');


### PR DESCRIPTION
This pull request has a new function to generate Signatures based on the account that has logged in instead of the Oauth application account. Everywhere that `repo.defaultSignature()` is called, has been replaced with `getSignature()`.