### PR TITLE
Issue#127 repo doesn't show up on the nav bar

### DIFF
--- a/app/components/addRepository/add.repository.component.html
+++ b/app/components/addRepository/add.repository.component.html
@@ -59,9 +59,10 @@
 	        <div class="right">
 	          <input type="text" name="folderLocal" class = "path-textbox" id="repoCreate"/>
 	          <button class="button-open" (click)="selectLocalRepoDirectory()">Create</button>
-	          <input type="file" id="dirPickerCreateLocal" name="localDir" (change)="createLocalRepository()" style="display: none;" webkitdirectory />
+	          <input type="file" id="dirPickerCreateLocal" name="localDir" (change)="createLocalRepository()" style="display: none;" />
 	        </div>
 
 	    </div>
   </div>
+</div>
 </div>

--- a/app/components/addRepository/add.repository.component.html
+++ b/app/components/addRepository/add.repository.component.html
@@ -59,7 +59,7 @@
 	        <div class="right">
 	          <input type="text" name="folderLocal" class = "path-textbox" id="repoCreate"/>
 	          <button class="button-open" (click)="selectLocalRepoDirectory()">Create</button>
-	          <input type="file" id="dirPickerCreateLocal" name="localDir" (change)="createLocalRepository()" style="display: none;" />
+	          <input type="file" id="dirPickerCreateLocal" name="localDir" (change)="createLocalRepository()" style="display: none;" webkitdirectory />
 	        </div>
 
 	    </div>

--- a/app/misc/repo.ts
+++ b/app/misc/repo.ts
@@ -181,17 +181,18 @@ function openRepository() {
   }
 
   hidePRPanel();
+  let fullLocalPath;
+  let localPath;
 
     // Full path is determined by either handwritten directory or selected by file browser
     if (document.getElementById("repoOpen").value == null || document.getElementById("repoOpen").value == "") {
-      let localPath = document.getElementById("dirPickerOpenLocal").files[0].webkitRelativePath;
-      let fullLocalPath = document.getElementById("dirPickerOpenLocal").files[0].path;
+      fullLocalPath = document.getElementById("dirPickerOpenLocal").files[0].path;
+      localPath = fullLocalPath.replace(/^.*[\\\/]/, '');
       previousOpen = document.getElementById("dirPickerOpenLocal").value;
       document.getElementById("repoOpen").value = fullLocalPath;
       document.getElementById("repoOpen").text = fullLocalPath;
     } else {
-      let localPath = document.getElementById("repoOpen").value;
-      let fullLocalPath;
+      localPath = document.getElementById("repoOpen").value;
       if (checkFile.existsSync(localPath)) {
         fullLocalPath = localPath;
       } else {
@@ -479,7 +480,7 @@ function refreshReferences(verbose, force) {
         }
         document.getElementById("repo-name").innerHTML = repoLocalPath;
         // TODO: add a condition here to switch between tag and branch name string
-          document.getElementById("branch-name").innerHTML = 'Branch: ' + '<span id="name-selected">' + branch +'</span>' + '<span class="caret"></span>';
+        document.getElementById("branch-name").innerHTML = 'Branch: ' + '<span id="name-selected">' + branch +'</span>' + '<span class="caret"></span>';
       }, function (err) {
         //If the repository has no commits, getCurrentBranch will throw an error.
         //Default values will be set for the branch labels


### PR DESCRIPTION
 Fixed:
- issue #127 where the repo name won't show up when open from a local repository.

Investigation reason: 
- the script tries to get path from webkitRelativePath which is an empty string as shown in the figure below.
![image](https://user-images.githubusercontent.com/19754074/59547075-99c92380-8eed-11e9-9012-03da7ad54efe.png)
- this likely is because angular 2 doesn't support `webkitdirectory`.

Solution:
- use regular expression to get directory name

After:
![image](https://user-images.githubusercontent.com/19754074/59547140-8e2a2c80-8eee-11e9-9ac9-797fec13138c.png)

