### PR TITLE
Issue #1 line number repeated in diff file

### DIFF
--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -1630,6 +1630,11 @@ function displayModifiedFiles() {
             element.style.backgroundColor = "#84db00";
           } else if (line.charAt(0) === "-") {
             element.style.backgroundColor = "#ff2448";
+          } else if (line.includes("No newline at end of file") {
+            // mimic the git diff command line tool and show this line anyway
+            // the line shows "<	12	<	\n\ No newline at end of file\n"
+            // so just show "\ No newline at end of file" as per git
+            line = "\ No newline at end of file"
           }
 
           // If not a changed line, origin will be a space character, so still need to slice
@@ -1804,7 +1809,7 @@ function setUpstreamRepo() {
       }
       else if (error.message == "remote 'upstream' already exists"){ //Checking for existing upstream branch
         displayModal("Upstream branch already exists");
-      } 
+      }
       }), displayModal("Upstream repository successfully configured.");
     }, function(err) {
       console.log("Error adding remote upstream repository:" + err) //Checking if a repo is opened before setting an upstream

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -1630,7 +1630,7 @@ function displayModifiedFiles() {
             element.style.backgroundColor = "#84db00";
           } else if (line.charAt(0) === "-") {
             element.style.backgroundColor = "#ff2448";
-          } else if (line.includes("No newline at end of file") {
+          } else if (line.includes("No newline at end of file")) {
             // mimic the git diff command line tool and show this line anyway
             // the line shows "<	12	<	\n\ No newline at end of file\n"
             // so just show "\ No newline at end of file" as per git


### PR DESCRIPTION
the newline message has an additional newline character in it, so just replace it with the new line message

ie replace "<	12	<	\n\ No newline at end of file\n"
with "\ No newline at end of file"

as per git CLI:
test-merge $ git diff AnotherFile.txt
diff --git a/AnotherFile.txt b/AnotherFile.txt
index 56c23e5..1999256 100644
--- a/AnotherFile.txt
+++ b/AnotherFile.txt
@@ -5,4 +5,8 @@ sadf
 asdf
 asdf
 asdf
-asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf
\ No newline at end of file
+asdfasdfasdfasdfasdfasdfasdfasdfasdfasdfasdf
+asdf
+asdf
+asdf
+asdf
\ No newline at end of file
