### PR TITLE
UI fixes for issue #171 ,#179 ,#180 ,#187  and feature to undo latest unpush commit.

### DIFF
--- a/app/components/filePanel/file.panel.component.html
+++ b/app/components/filePanel/file.panel.component.html
@@ -1,10 +1,10 @@
 <div class="file-panel" id="file-panel">
   <!-- UNSTAGED FILES -->
   <div class="modified-files-header" id="modified-files-header">
-    <h4 style="color: white" id="unstaged-files-heading">Unstaged Files</h4>
+    <h4 class="filepanel-headings" id="unstaged-files-heading">Unstaged Files</h4>
     <button class="staging-buttons" id="stage-all">Stage All</button>
   </div>
-  <div class="files-changed" id="files-changed" style="min-height: 30%">
+  <div class="files-changed" id="files-changed">
     <p class="modified-files-message" id="modified-files-message">Your modified files will appear here</p>
     <div class="file" *ngFor="let file of files">
       <p>{{file}}</p>
@@ -14,10 +14,10 @@
 
   <!-- STAGED FILES -->
   <div class="staged-files-header" id="staged-files-header">
-    <h4 style="color: white" id="staged-files-heading">Staged Files</h4>
+    <h4 class="filepanel-headings" id="staged-files-heading">Staged Files</h4>
     <button class="staging-buttons" id="unstage-all">Unstage All</button>
   </div>
-  <div class="files-staged" id="files-staged" style="min-height: 30%">
+  <div class="files-staged" id="files-staged">
     <p class="modified-files-message" id="staged-files-message">Your staged files will appear here</p>
     <div class="file" *ngFor="let file of files">
       <p>{{file}}</p>

--- a/app/components/graphPanel/graph.panel.component.html
+++ b/app/components/graphPanel/graph.panel.component.html
@@ -11,7 +11,8 @@
 
   <!-- Context menu for operations within the commit network -->
   <div id="networkContext" class="context-menu" tabindex="-1" (blur)="disableContextMenu()">
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu" id="nodeRightClickMenu">
+      
       <li>
         <a (mousedown)="doNothing()" (click)="showCreateTagModal()">Create tag</a>
       </li>
@@ -19,6 +20,9 @@
         <a (click)="showDeleteTagList()">Delete a tag</a>
       </li>
       <li id="deleteTagList"></li>
+      <li id="rightClickMenuItemReset">
+          <a (click)="resetRepoToCommit()" title="undo the latest unpush commit from the current branch">Undo Latest Commit</a>
+      </li>
     </ul>
   </div>
 

--- a/app/components/graphPanel/graph.panel.component.ts
+++ b/app/components/graphPanel/graph.panel.component.ts
@@ -28,6 +28,13 @@ export class GraphPanelComponent {
 
   }
 
+  resetRepoToCommit ()
+  {
+    resetLastCommit()
+    let contextMenu = $("#networkContext");
+    contextMenu.hide();
+  }
+
   // Disables the context menu in the graphed network
   disableContextMenu() {
     let contextMenu = $("#networkContext");

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -209,7 +209,7 @@ function addAndCommit() {
       hideDiffPanel();
       clearStagedFilesList();
       clearCommitMessage();
-
+      displayModal("Commit successful");
       for (let i = 0; i < filesToAdd.length; i++) {
         addCommand("git add " + filesToAdd[i]);
       }
@@ -1882,4 +1882,18 @@ function unpushedCommitsModal() {
 
   });
 
+}
+
+//undo the latest unpush single commit using git reset --soft HEAD~1
+//TODO support for undo any number of commit user want
+function resetLastCommit()
+{
+  let sGitRepo = sGit(repoFullPath);
+  sGitRepo.silent(true).reset(["HEAD~1"]).then((result) => {
+    displayModal("Most recent unpush commit has been reset");
+  } ).catch( function ( err )
+  {
+    alert("Reset Failed : "+ err.message );
+    console.log( err );
+  });
 }

--- a/app/misc/graphSetup.ts
+++ b/app/misc/graphSetup.ts
@@ -8,8 +8,10 @@ let options, bsNodes, bsEdges, nodes, edges, network;
 let secP = null, fromNode = null, toNode;
 
 let GraphNodeID = 0;
- 
-function returnSelectedNodeValue():number{
+var resetNodeMenuItem = undefined
+
+function returnSelectedNodeValue (): number
+{
     let returnValue = GraphNodeID;
     GraphNodeID = 0;
     return returnValue;
@@ -236,7 +238,19 @@ function drawGraph() {
                     contextMenu.css({
                         top: properties.event.pageY + "px",
                         left: properties.event.pageX + "px"
-                    });
+                    } );
+                    if ( resetNodeMenuItem == undefined )
+                    {
+                        resetNodeMenuItem = $( "#rightClickMenuItemReset" );
+                    }
+                    if ( aheadCommitList.includes( contextNode.commitSha ) )
+                    {
+                        let contextMenuItems = $( "#nodeRightClickMenu" );
+                        contextMenuItems.append( resetNodeMenuItem );
+                    } else
+                    {
+                        resetNodeMenuItem.remove();
+                    }
                     contextMenu.finish().toggle();
                     contextMenu.focus();
 

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -233,13 +233,18 @@ body .navbar .dropdown-toggle {
   margin-top: 10px;
 }*/
 
+.filepanel-headings {
+  color: white;
+  float: left;
+}
+
 body .file-panel {
   width: 20%;
-  height: 70vh;
+  height: 80vh;
   background-color: #282828;
   float: left;
   z-index: 0;
-  overflow-y: auto;
+  /* overflow-y: auto; */
 }
 
 body .file-panel .modified-files-header .staged-files-header .select-all-message {
@@ -254,12 +259,21 @@ body .file-panel .files-changed .modified-files-message {
 }
 
 body .file-panel .files-staged .modified-files-message {
-    padding: 20px;
+  padding: 20px;
 }
 
 body .file-panel .files-changed .file {
   width: 99%;
   height: 10%;
+  position: relative;
+  overflow: hidden;
+  border: 1px solid #fff;
+}
+
+.file {
+  width: 99%;
+  height: 10%;
+  min-height: 40px;
   position: relative;
   overflow: hidden;
   border: 1px solid #fff;
@@ -274,6 +288,23 @@ body .file-panel .files-changed .files-staged .file p {
   text-overflow: ellipsis;
   overflow: hidden;
   width: 80%;
+}
+
+.file-path {
+  float: right;
+  width: 95%;
+}
+
+.files-changed {
+  overflow-y: auto;
+  min-height: 25%;
+  max-height: 35%;
+}
+
+.files-staged {
+  overflow-y: auto;
+  min-height: 25%;
+  max-height: 35%;
 }
 
 body .file-panel .files-changed .files-staged .file input {
@@ -1142,11 +1173,12 @@ div.wiki-header button.close-button, div.wiki-header button.open-button {
 /*
   Pull request related css.
 */
+
 body .pull-request-panel {
   background-color: #282828;
   display: block;
+  height: 80vh;
   float: right;
-  height: 60vh;
   overflow-y: auto;
   transition: .5s;
   width: 60px;

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -367,7 +367,7 @@ body .body-panel {
 
 body .body-panel .diff-panel {
   width: 0;
-  height: 100%;
+  height: 80vh;
   float: left;
 }
 


### PR DESCRIPTION
This PR fixes:- 
#171 correct message on successful commit
#179 if we have too many files in the file-changed section it was a mess. fixed!
#180 checkbox for the files are now infront of them aligned to text. Note: file block size is still large to look prity. (i checked small does not look that cool and will create an uneven block in case of the large filename)
#187 as shown during planing the panels on both sides of the graph were little shorter then needed.fixed!

also #181 , you can now right-click an unpushed commit to undo the latest commit from that branch. 
Note: right-clicking on pushed commit does not have the undo option.

@jtiz003  demo for 181:- https://youtu.be/YXY0OlDC4ks