### PR TITLE
Ensured there is a commit to center on before centering.

### DIFF
--- a/app/misc/graphing.ts
+++ b/app/misc/graphing.ts
@@ -695,7 +695,10 @@ function reCenter() {
         }
     };
 
-    network.focus(commitList[commitList.length - 1]["id"], moveOptions);
+    // Recenter on the first commit
+    if (commitList.length > 0) {
+        network.focus(commitList[commitList.length - 1]["id"], moveOptions);
+    }
 }
 
 // Open a specific commit's dialog box


### PR DESCRIPTION
Really basic fix. In a new repo there are no commits so when loading a graph we need to test that there is a commit before trying to center on the first commit.