### PR TITLE
Editing errors for consistency

### DIFF
--- a/app/components/app/app.component.ts
+++ b/app/components/app/app.component.ts
@@ -24,7 +24,7 @@ export class AppComponent {
     // If user has previously saved a color, then set the app to that color
     if (fs.existsSync(userColorFilePath)) {
       fs.readFile(userColorFilePath, function(err, buffer) {
-        console.log(buffer.toString());
+        console.log("Last used theme: " + buffer.toString() + ", initializing to this theme.");
         let color = buffer.toString();
         changeColor(color);
       });

--- a/app/components/textEditor/text.editor.component.ts
+++ b/app/components/textEditor/text.editor.component.ts
@@ -13,7 +13,7 @@ export class TextEditorComponent {
   // Stores the last key pressed by the user.
   currentKey: string;
 
-  // True when the last change was cut or paste. 
+  // True when the last change was cut or paste.
   cutPastePressed = false;
 
   // True when the line text area is being populated.
@@ -22,7 +22,7 @@ export class TextEditorComponent {
   // Amount of spaces to be added on 'Tab' press.
   numberOfSpacesToIndent = 4;
 
-  // Stores number of files that have been opened in this session. 
+  // Stores number of files that have been opened in this session.
   latestFileId = 0;
 
   // Stores the id of the currently open file tab.
@@ -101,7 +101,7 @@ export class TextEditorComponent {
     }
   }
 
-  /* 
+  /*
     This function is used to close the editor and return
     to the main screen.
   */
@@ -134,7 +134,7 @@ export class TextEditorComponent {
     this.filePaths = [""];
   }
 
-  /* 
+  /*
   This function is used to hide the editor and return
   to the main screen.
 */
@@ -174,7 +174,7 @@ export class TextEditorComponent {
     }
 
     /*
-      Show the clicked file tab, and add an "active" class to the 
+      Show the clicked file tab, and add an "active" class to the
       button that opened the tab
     */
     let fileIdElement = document.getElementById(fileId);
@@ -236,7 +236,7 @@ export class TextEditorComponent {
   }
 
   /*
-    Store the last key pressed. Required to decide when 
+    Store the last key pressed. Required to decide when
     to repopulate the line numbers.
   */
   keyPressed(event: KeyboardEvent): void {
@@ -273,7 +273,7 @@ export class TextEditorComponent {
 
   /*
     This function is called whenever there is a change in
-    the file text area. It repopulates the line numbers 
+    the file text area. It repopulates the line numbers
     depending on what action the user takes.
   */
   valueChanged(): void {
@@ -294,7 +294,7 @@ export class TextEditorComponent {
   }
 
   /*
-    Update the number of spaces to indent based 
+    Update the number of spaces to indent based
     on selection.
   */
   updateIndentAmount(): void {
@@ -303,7 +303,7 @@ export class TextEditorComponent {
   }
 
   /*
-    Get content of text area and file name and 
+    Get content of text area and file name and
     save the contents.
   */
   saveFile(): void {
@@ -360,7 +360,8 @@ This function sets current and default folder for the file move dialog before op
     if (err) {
       // Inform user of error.
       displayModal("An error occured when saving, please try again.");
-      console.log(err);
+      let savingError = err;
+      console.log("ERROR while saving: " + savingError);
     } else {
       // Change save button to saved, remove star next to filename
       let saveButton = document.getElementById("save-button");

--- a/app/misc/authenticate.ts
+++ b/app/misc/authenticate.ts
@@ -182,7 +182,6 @@ function authenticateUser(callback) {
     }, err => {
       console.log('ERROR while getting token. ', err);
 	}).catch( err => {
-    let tokenError = err;
     console.log("Token error: " + err);
   });
 }

--- a/app/misc/authenticate.ts
+++ b/app/misc/authenticate.ts
@@ -129,7 +129,7 @@ function searchRepoName() {
     for (let i = 0; i < data.length; i++) {
 
       let rep = Object.values(data)[i];
-      console.log("url of repo: " + rep['html_url']);
+      // console.log("url of repo: " + rep['html_url']);
 
       // Searches from the text input and adds to the list if repo name is found
       if (parseInt(rep['forks_count']) == 0) {
@@ -181,9 +181,10 @@ function authenticateUser(callback) {
       });
 
     }, err => {
-      console.log('Error while getting token', err);
+      console.log('ERROR while getting token. ', err);
 	}).catch( err => {
-    console.log(err);
+    let tokenError = err;
+    console.log("Token error: " + err);
   });
 }
 
@@ -219,6 +220,7 @@ function getUserInfo(callback) {
       }
       else {
         displayModal(err);
+        console.log("ERROR fetching user information: " + err);
       }
       document.getElementById('grey-out').style.display = 'none';
     }
@@ -242,6 +244,7 @@ function submitOTP(callback) {
   }, function (err, id, token, headers) {
     if (err) {
       displayModal(err);
+      console.log("ERROR submitting OTP: " + err);
     }
     else {
       client = github.client(token);
@@ -256,6 +259,7 @@ function processLogin(ghme, callback) {
   ghme.info(function(err, data, head) {
     if (err) {
       displayModal(err);
+      console.log("ERROR processing login: " + err);
     } else {
       avaterImg = Object.values(data)[2]
       document.getElementById("githubname").innerHTML = data["login"]
@@ -271,10 +275,13 @@ function processLogin(ghme, callback) {
     } else {
        displayUsername();
       document.getElementById("avatar").innerHTML = "Sign out";
-      console.log("number of repos: " + data.length);
+      console.log("Number of repos associated to logged in user: " + data.length + " To display urls of said repos, uncomment the log below this one in processLogin() in authenticate.ts.");
       for (let i = 0; i < data.length; i++) {
         let rep = Object.values(data)[i];
-        console.log("url of repo: " + rep['html_url']);
+        // The following line lists the URL of all the repos associated with the logged in user.
+        // It was clogging the debugging console with unneccessary information so it's been commented
+        // out for the time being.
+        // console.log("url of repo: " + rep['html_url']);
 
         if(rep['fork'] == false) {
           if(parseInt(rep['forks_count']) == 0) {
@@ -315,7 +322,7 @@ function selectRepo(ele) {
   if (butt.innerHTML != 'Clone'){
     butt.disabled = false;
   }
-  console.log("selected " + ele.innerHTML + " as repository");
+  console.log("Selected " + ele.innerHTML + " as repository");
 }
 
 function cloneRepo() {
@@ -326,16 +333,16 @@ function cloneRepo() {
 
   hidePRPanel();
 
-  console.log("cloning " + url);
+  console.log("Cloning " + url);
   let splitUrl = url.split("/");
   let local;
   if (splitUrl.length >= 2) {
     local = splitUrl[splitUrl.length - 1];
   }
-  console.log("cloning " + local);
+  console.log("Cloning " + local);
 
   if (local == null) {
-    updateModalText("Error: could not define name of repo");
+    updateModalText("Error: could not define name of repo.");
     return;
   }
 

--- a/app/misc/color.ts
+++ b/app/misc/color.ts
@@ -14,7 +14,7 @@ function changeColor(color) {
   // Save user color selection
   if (color != null) {
     fs.writeFile(userColorFilePath, color, function(err) {
-        if (err) console.log("Cannot write colour to file: " + err);
+        if (err) console.log("ERROR cannot write colour to file. Reason: " + err);
     });
   }
 
@@ -53,7 +53,8 @@ function changeColor(color) {
 
   if (color === 'white') {
     for (let i = 0; i < head.length; i++) {
-      console.log(head[i]);
+      // Currently unneeded nav class printout.
+      // console.log(head[i]);
       head[i].className = 'navbar navbar-white';
     }
     for (let i = 0; i < headButton.length; i++) {
@@ -102,12 +103,13 @@ function changeColor(color) {
     if (stagedMessageColor != null) {
       stagedMessageColor.style.color = '#000000';
     }
-    
+
     before = 'white';
   }
   else if (color === 'pink') {
     for (var i = 0; i < head.length; i++) {
-            console.log(head[i]);
+            // Currently unneeded nav class printout.
+            // console.log(head[i]);
             head[i].className = 'navbar navbar-pink';
         }
         for (var i = 0; i < headButton.length; i++) {
@@ -117,14 +119,14 @@ function changeColor(color) {
             headButton[i].classList.add('btn-default');
         }
         for (var i = 0; i < fa.length; i++) {
-            fa[i].setAttribute('style', 'color:white'); 
+            fa[i].setAttribute('style', 'color:white');
         }
         fp.setAttribute('style', 'background-color: #FFC2C2');
         for (var i = 0; i < p.length; i++) {
             p[i].style.color = '#000000';
         }
         for (var i = 0; i < h1.length; i++) {
-            h1[i].style.color = '#FFA3A3'; 
+            h1[i].style.color = '#FFA3A3';
         }
         for (let i = 0; i < stashes.length; i++){
           stashes[i].style.color = "#000000";
@@ -133,11 +135,11 @@ function changeColor(color) {
 
         changeTextColor('#000000');
 
-        diffp.style.color = '#000000'; 
+        diffp.style.color = '#000000';
         diffp.style.backgroundColor = 'white';
         diffPanel.style.backgroundColor = 'white';
         network.style.backgroundColor = '#FFE5E5';
-        footer.style.backgroundColor = '#FFD7D7'; 
+        footer.style.backgroundColor = '#FFD7D7';
         footer.style.border = '#FFD7D7';
         arp.style.backgroundColor = '#FFD7D7';
         auth.style.backgroundColor = '#FFE5E5';
@@ -160,7 +162,8 @@ function changeColor(color) {
     }
     else if (color === 'blue') {
       for (var i = 0; i < head.length; i++) {
-              console.log(head[i]);
+              // Currently unneeded nav class printout.
+              // console.log(head[i]);
               head[i].className = 'navbar navbar-blue';
           }
           for (var i = 0; i < headButton.length; i++) {
@@ -170,14 +173,14 @@ function changeColor(color) {
               headButton[i].classList.add('btn-default');
           }
           for (var i = 0; i < fa.length; i++) {
-              fa[i].setAttribute('style', 'color:white'); 
+              fa[i].setAttribute('style', 'color:white');
           }
-          fp.setAttribute('style', 'background-color: #9DD2FE'); 
+          fp.setAttribute('style', 'background-color: #9DD2FE');
           for (var i = 0; i < p.length; i++) {
               p[i].style.color = '#000000';
           }
           for (var i = 0; i < h1.length; i++) {
-              h1[i].style.color = '#4EAFFE'; 
+              h1[i].style.color = '#4EAFFE';
           }
           for (let i = 0; i < stashes.length; i++){
             stashes[i].style.color = "#000000";
@@ -186,13 +189,13 @@ function changeColor(color) {
 
           changeTextColor('#000000');
 
-          diffp.style.color = '#000000'; 
-          diffp.style.backgroundColor = 'white'; 
+          diffp.style.color = '#000000';
+          diffp.style.backgroundColor = 'white';
           diffPanel.style.backgroundColor = 'white';
-          network.style.backgroundColor = '#EEF6FF'; 
-          footer.style.backgroundColor = '#B6DEFF'; 
-          footer.style.border = '#B6DEFF'; 
-          arp.style.backgroundColor = '#DAEEFF'; 
+          network.style.backgroundColor = '#EEF6FF';
+          footer.style.backgroundColor = '#B6DEFF';
+          footer.style.border = '#B6DEFF';
+          arp.style.backgroundColor = '#DAEEFF';
           auth.style.backgroundColor = '#DAEEFF';
           repoName.style.color = '#fff';
           branchName.style.color = '#fff';
@@ -201,19 +204,20 @@ function changeColor(color) {
           diffChangePopUp.style.backgroundColor = '#B6DEFF';
           commitDiffPanel.style.backgroundColor = '#fff';
           stashTitle.style.color = '#000000';
-         
+
           if (modifiedMessageColor != null) {
             modifiedMessageColor.style.color = '#fff';
           }
           if (stagedMessageColor != null) {
             stagedMessageColor.style.color = '#fff';
           }
-          
+
           before = 'blue';
     }
     else if (color === 'navy') {
       for (var i = 0; i < head.length; i++) {
-              console.log(head[i]);
+              // Currently unneeded nav class printout.
+              // console.log(head[i]);
               head[i].className = 'navbar navbar-navy';
           }
           for (var i = 0; i < headButton.length; i++) {
@@ -225,7 +229,7 @@ function changeColor(color) {
           for (var i = 0; i < fa.length; i++) {
               fa[i].setAttribute('style', 'color:white');
           }
-          fp.setAttribute('style', 'background-color: #0066FF'); 
+          fp.setAttribute('style', 'background-color: #0066FF');
           for (var i = 0; i < p.length; i++) {
               p[i].style.color = '#000000';
           }
@@ -239,14 +243,14 @@ function changeColor(color) {
 
           changeTextColor('#000000');
 
-          diffp.style.color = '#000000';  
+          diffp.style.color = '#000000';
           diffp.style.backgroundColor = 'white';
           diffPanel.style.backgroundColor = 'white';
-          network.style.backgroundColor = '#CCE0FF'; 
+          network.style.backgroundColor = '#CCE0FF';
           network.style.border = '#CCE0FF';
-          footer.style.backgroundColor = '#4D94FF'; 
-          footer.style.border = '#4D94FF'; 
-          arp.style.backgroundColor = '#4D94FF'; 
+          footer.style.backgroundColor = '#4D94FF';
+          footer.style.border = '#4D94FF';
+          arp.style.backgroundColor = '#4D94FF';
           auth.style.backgroundColor = '#4D94FF';
           repoName.style.color = '#fff';
           branchName.style.color = '#fff';
@@ -255,7 +259,7 @@ function changeColor(color) {
           diffChangePopUp.style.backgroundColor = '#0066FF';
           commitDiffPanel.style.backgroundColor = '#fff';
           stashTitle.style.color = '#000000';
-          
+
           if (modifiedMessageColor != null) {
             modifiedMessageColor.style.color = '#fff';
           }
@@ -267,7 +271,8 @@ function changeColor(color) {
     }
     else if (color === 'green') {
       for (var i = 0; i < head.length; i++) {
-              console.log(head[i]);
+        // Currently unneeded nav class printout.
+              // console.log(head[i]);
               head[i].className = 'navbar navbar-green';
           }
           for (var i = 0; i < headButton.length; i++) {
@@ -277,14 +282,14 @@ function changeColor(color) {
               headButton[i].classList.add('btn-default');
           }
           for (var i = 0; i < fa.length; i++) {
-              fa[i].setAttribute('style', 'color:white'); 
+              fa[i].setAttribute('style', 'color:white');
           }
-          fp.setAttribute('style', 'background-color: #5CD65C'); 
+          fp.setAttribute('style', 'background-color: #5CD65C');
           for (var i = 0; i < p.length; i++) {
               p[i].style.color = '#000000';
           }
           for (var i = 0; i < h1.length; i++) {
-              h1[i].style.color = '#00990d'; 
+              h1[i].style.color = '#00990d';
           }
           for (let i = 0; i < stashes.length; i++){
             stashes[i].style.color = "#000000";
@@ -293,14 +298,14 @@ function changeColor(color) {
 
           changeTextColor('#000000');
 
-          diffp.style.color = '#000000'; 
-          diffp.style.backgroundColor = 'white'; 
+          diffp.style.color = '#000000';
+          diffp.style.backgroundColor = 'white';
           diffPanel.style.backgroundColor = 'white';
-          network.style.backgroundColor = '#EBFAEB'; 
-          footer.style.backgroundColor = '#ADEBAD'; 
-          footer.style.border = '#ADEBAD'; 
-          arp.style.backgroundColor = '#ADEBAD'; 
-          auth.style.backgroundColor = '#ADEBAD'; 
+          network.style.backgroundColor = '#EBFAEB';
+          footer.style.backgroundColor = '#ADEBAD';
+          footer.style.border = '#ADEBAD';
+          arp.style.backgroundColor = '#ADEBAD';
+          auth.style.backgroundColor = '#ADEBAD';
           repoName.style.color = '#fff';
           branchName.style.color = '#fff';
           modifiedTitle.style.color = '#fff';
@@ -308,7 +313,7 @@ function changeColor(color) {
           diffChangePopUp.style.backgroundColor = '#ADEBAD';
           commitDiffPanel.style.backgroundColor = '#fff';
           stashTitle.style.color = '#000000';
-          
+
           if (modifiedMessageColor != null) {
           modifiedMessageColor.style.color = '#fff';
         }
@@ -317,10 +322,11 @@ function changeColor(color) {
         }
 
           before = 'green';
-  } 
+  }
   else if (color === 'default') {
     for (let i = 0; i < head.length; i++) {
-      console.log(head[i]);
+      // Currently unneeded nav class printout.
+      // console.log(head[i]);
       head[i].className = 'navbar navbar-inverse';
     }
     for (let i = 0; i < headButton.length; i++) {
@@ -379,7 +385,7 @@ function changeColor(color) {
       diffChangePanelText[i].setAttribute('style', 'color:' + textColor);
     }
   }
-  
+
   // Match the style of the file editor to the rest of the app
   editor!.style.color = diffp.style.color;
   editor!.style.backgroundColor = network.style.backgroundColor;

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -39,7 +39,7 @@ function sortedListOfCommits(commits){
 
     while (commits.length > 0) {
       let commit = commits.shift();
-      let parents = commit.parentxs();
+      let parents = commit.parents();
       if (parents === null || parents.length === 0) {
         commitHistory.push(commit);
       } else {

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -21,7 +21,7 @@ let vis = require("vis");
 let commitHistory = [];
 let commitToRevert = 0;
 let commitHead = 0;
-let commitID = 0;
+let commitID = 0;x
 let lastCommitLength;
 let refreshAllFlagCommit = false;
 
@@ -39,7 +39,7 @@ function sortedListOfCommits(commits){
 
     while (commits.length > 0) {
       let commit = commits.shift();
-      let parents = commit.parents();
+      let parents = commit.parentxs();
       if (parents === null || parents.length === 0) {
         commitHistory.push(commit);
       } else {
@@ -1870,9 +1870,9 @@ function moveFile(filesource:string, filedestination:string, skipFileExistTest:b
         .mv(filesource, filedestination)  //perform GIT MV operation
         .then(() => console.log('File move completed.'))
         .catch((err) => {
-          displayModal('File move failed: ' + err));
+          displayModal('File move failed: ' + err);
           console.log("ERROR: file move failed. Full error: " + err);
-      }
+        });
   }
   else{
     displayModal("Destination directory does not exist.");

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -88,12 +88,12 @@ function stage() {
   Git.Repository.open(repoFullPath)
     .then(function (repoResult) {
       repository = repoResult;
-      console.log("found a repository");
+      console.log("Found a repository.");
       return repository.refreshIndex();
     })
 
     .then(function (indexResult) {
-      console.log("found a file to stage");
+      console.log("Found a file to stage.");
       index = indexResult;
       let filesToStage = [];
       filesToAdd = [];
@@ -106,7 +106,7 @@ function stage() {
         }
       }
       if (filesToStage.length > 0) {
-        console.log("staging files");
+        console.log("Staging files.");
         stagedFiles = index.addAll(filesToStage);
       } else {
         //If no files checked, then throw error to stop empty commits
@@ -133,12 +133,12 @@ function addAndCommit() {
   Git.Repository.open(repoFullPath)
     .then(function (repoResult) {
       repository = repoResult;
-      console.log("found a repository");
+      console.log("Found a repository.");
       return repository.refreshIndex();
     })
 
     .then(function (indexResult) {
-      console.log("found a file to stage");
+      console.log("Found a file to stage.");
       index = indexResult;
       let filesToStage = [];
       filesToAdd = [];
@@ -151,7 +151,7 @@ function addAndCommit() {
         }
       }
       if (filesToStage.length > 0) {
-        console.log("staging files");
+        console.log("Staging files.");
         return index.addAll(filesToStage);
       } else {
         //If no files checked, then throw error to stop empty commits
@@ -160,28 +160,28 @@ function addAndCommit() {
     })
 
     .then(function () {
-      console.log("found an index to write result to");
+      console.log("Found an index to write result to.");
       return index.write();
     })
 
     .then(function () {
-      console.log("creating a tree object using current index");
+      console.log("Creating a tree object using current index.");
       return index.writeTree();
     })
 
     .then(function (oidResult) {
-      console.log("changing " + oid + " to " + oidResult);
+      console.log("Changing " + oid + " to " + oidResult + ".");
       oid = oidResult;
       return Git.Reference.nameToId(repository, "HEAD");
     })
 
     .then(function (head) {
-      console.log("found the current commit");
+      console.log("Found the current commit.");
       return repository.getCommit(head);
     })
 
     .then(function (parent) {
-      console.log("Verifying account");
+      console.log("Verifying account.");
       let sign;
 
       sign = getSignature(repository);
@@ -191,17 +191,17 @@ function addAndCommit() {
 
       if (readFile.exists(repoFullPath + "/.git/MERGE_HEAD")) {
         let tid = readFile.read(repoFullPath + "/.git/MERGE_HEAD", null);
-        console.log("head commit on remote: " + tid);
-        console.log("head commit on local repository: " + parent.id.toString());
+        console.log("Head commit on remote: " + tid);
+        console.log("Head commit on local repository: " + parent.id.toString());
         return repository.createCommit("HEAD", sign, sign, commitMessage, oid, [parent.id().toString(), tid.trim()]);
       } else {
-        console.log('no other commits');
+        console.log('No other commits.');
         return repository.createCommit("HEAD", sign, sign, commitMessage, oid, [parent]);
       }
     })
     .then(function (oid) {
       theirCommit = null;
-      console.log("Committing");
+      console.log("Committing.");
       changes = 0;
       CommitButNoPush = 1;
       console.log("Commit successful: " + oid.tostrS());
@@ -221,6 +221,7 @@ function addAndCommit() {
       // Added error thrown for if files not selected
       if (err.message == "No files selected to commit.") {
         displayModal(err.message);
+        console.log("ERROR: " + err.message);
       } else {
         updateModalText("You have not logged in. Please login to commit a change");
       }
@@ -271,7 +272,7 @@ function checkCommitChange() {
         let history = commit.history();
         history.on("end", function (commits) {
           if (lastCommitLength !== commits.length) {
-            console.log("commit graph changes detected");
+            console.log("Commit graph changes detected, refreshing graph.");
             // show refresh graph alert
             if (!refreshAllFlagCommit) {
               $("#refresh-graph-alert").show();
@@ -296,22 +297,22 @@ function getAllCommits(callback) {
   let repos;
   let allCommits = [];
   let aclist = [];
-  console.log("Finding all commits");
+  console.log("Finding all commits.");
   Git.Repository.open(repoFullPath)
     .then(function (repo) {
       repos = repo;
-      console.log("fetching all refs");
+      console.log("Fetching all refs.");
       return repo.getReferences(Git.Reference.TYPE.LISTALL);
     })
     .then(function (refs) {
       let count = 0;
-      console.log("getting " + refs.length + " refs");
+      console.log("Getting " + refs.length + " refs.");
       // while loop of asynchronous requests
       async.whilst(
         function test(cb) { cb(null, count < refs.length) },
         function (cb) {
           if (!refs[count].isRemote()) {
-            console.log("referenced branch exists on remote repository");
+            console.log("Referenced branch exists on remote repository.");
             refs[count].peel(Git.Object.TYPE.COMMIT)
             .then(function(ref) {
               repos.getCommit(ref)
@@ -325,7 +326,7 @@ function getAllCommits(callback) {
                     }
                   }
                   count++;
-                  console.log(count + " out of " + allCommits.length + " commits");
+                  console.log(count + " out of " + allCommits.length + " commits.");
                   cb();
                 });
 
@@ -333,7 +334,7 @@ function getAllCommits(callback) {
               });
             })
           } else {
-            console.log('current branch does not exist on remote');
+            console.log('Current branch does not exist on remote.');
             count++;
             cb();
           }
@@ -364,9 +365,9 @@ function pullFromRemote() {
   Git.Repository.open(repoFullPath)
     .then(function (repo) {
       repository = repo;
-      console.log("Pulling new changes from the remote repository");
+      console.log("Pulling new changes from the remote repository.");
       addCommand("git pull");
-      displayModal("Pulling new changes from the remote repository");
+      displayModal("Pulling new changes from the remote repository.");
 
       return repository.fetchAll({
         callbacks: {
@@ -383,10 +384,10 @@ function pullFromRemote() {
     }).then(function () {
       return Git.Reference.nameToId(repository, "refs/remotes/origin/" + branch);
     }).then(function (oid) {
-      console.log("Looking up commit with id " + oid + " in all repositories");
+      console.log("Looking up commit with id " + oid + " in all repositories.");
       return Git.AnnotatedCommit.lookup(repository, oid);
     }).then(function (annotated) {
-      console.log("merging " + annotated + "with local forcefully");
+      console.log("Merging " + annotated + "with local forcefully.");
       Git.Merge.merge(repository, annotated, null, {
         checkoutStrategy: Git.Checkout.STRATEGY.FORCE,
       });
@@ -412,7 +413,7 @@ function pullFromRemote() {
       //anywhere during the above process if there is a error the following catch will catch and report it
       //and stop the process then and there.
     }).catch(function(err) {
-      console.log(err);
+      console.log("ERROR: Pull failed. Full error: " + err);
       updateModalText("Pull Failed : "+err.message);
     });
 
@@ -422,7 +423,7 @@ function pushToRemote() {
   let branch = document.getElementById("name-selected").innerText;
   Git.Repository.open(repoFullPath)
     .then(function (repo) {
-      console.log("Pushing changes to remote")
+      console.log("Pushing changes to remote.")
       displayModal("Pushing changes to remote...");
       console.log("Branch name: " + branch);
       addCommand("git push -u origin " + branch);
@@ -443,11 +444,11 @@ function pushToRemote() {
         }).then(function() {
           CommitButNoPush = 0;
           window.onbeforeunload = Confirmed;
-          console.log("Push successful");
+          console.log("Push successful.");
           updateModalText("Push successful");
           refreshAll(repo);
         }).catch(function(err) {
-          console.log(err);
+          console.log("ERROR: Push failed. Full error: " + err);
           updateModalText("Push Failed : "+err.message);
           });
         });
@@ -506,7 +507,7 @@ function createBranch() {
   else {
     let currentRepository;
 
-    console.log(branchName + " is being created");
+    console.log("Branch " + branchName + " is being created.");
     Git.Repository.open(repoFullPath)
       .then(function (repo) {
         // Create a new branch on head
@@ -585,7 +586,7 @@ function isIllegalBranchName(branchName: string) : boolean {
 function deleteLocalBranch() {
   $('#delete-branch-modal').modal('toggle') // open warning modal
   let branchName = document.getElementById("branch-to-delete").value; // selected branch name
-  console.log("deleting branch: " + branchName)
+  console.log("Deleting branch: " + branchName)
   let repos;
   console.log(branchName + " is being deleted...")
   Git.Repository.open(repoFullPath)
@@ -599,7 +600,7 @@ function deleteLocalBranch() {
       })
     }).then(function () {
       // refresh graph
-      console.log("deleted the local branch")
+      console.log("Deleted the local branch.")
       refreshAll(repos);
     })
 }
@@ -615,7 +616,7 @@ function deleteRemoteBranch() {
     .then(function (repo) {
       Git.Reference.list(repo).then(function (array) {
         if (array.includes("refs/remotes/origin/" + branchName)) {  // check if the branch is remote
-          console.log("this is a remote branch")
+          console.log("This is a remote branch.")
 
           // delete the remote branch
           repo.getRemote('origin').then(function (remote) {
@@ -627,14 +628,14 @@ function deleteRemoteBranch() {
                   }
                 }
               }).then(function () {
-                console.log("deleted the remote branch")
-                updateModalText("The remote branch: " + branchName + " has been deleted")
+                console.log("Deleted the remote branch.")
+                updateModalText("The remote branch " + branchName + " has been deleted.")
               });
           })
         }
         else {
-          console.log("this is a local branch")
-          updateModalText("A remote branch called: " + branchName + " does not exist.")
+          console.log("This is a local branch.")
+          updateModalText("A remote branch named " + branchName + " does not exist.")
           return;
         }
       })
@@ -654,12 +655,12 @@ function mergeLocalBranches(element) {
       return repos.getBranch("refs/heads/" + bn);
     })
     .then(function (branch) {
-      console.log("branch to merge from: " + branch.name());
+      console.log("Branch to merge from: " + branch.name());
       fromBranch = branch;
       return repos.getCurrentBranch();
     })
     .then(function (toBranch) {
-      console.log("branch to merge to: " + toBranch.name());
+      console.log("Branch to merge to: " + toBranch.name());
       return repos.mergeBranches(toBranch,
         fromBranch,
         getSignature(repos),
@@ -702,7 +703,7 @@ function createTag(tagName: string, commitSha: string, pushTag: boolean, message
     .then(function(tagOid){
       // Push the tag if desired
       if (pushTag) {
-        console.log("Pushing tag: " + tagName);
+        console.log("Pushing tag " + tagName);
         return repo.getRemotes()
           .then(function (remotes) {
             return repo.getRemote(remotes[0]);
@@ -719,7 +720,7 @@ function createTag(tagName: string, commitSha: string, pushTag: boolean, message
               }
             );
           }).then(function(){
-            console.log("Successfully pushed tag: " + tagName);
+            console.log("Successfully pushed tag " + tagName);
           });
       }
     })
@@ -730,8 +731,8 @@ function createTag(tagName: string, commitSha: string, pushTag: boolean, message
       refreshAll(repo)
     })
     .catch(function(msg){
-      let errorMessage = "Error: " + msg.message;
-      console.log(errorMessage);
+      let errorMessage = msg.message;
+      console.log("ERROR creating tag: " + errorMessage + ". Error thrown by createTag() in git.ts.");
       $("#createTagError")[0].innerHTML = errorMessage;
 
       // Re-enable the submit button
@@ -750,11 +751,11 @@ function mergeCommits(from) {
       return Git.Reference.nameToId(repos, 'refs/heads/' + from);
     })
     .then(function (oid) {
-      console.log("Looking for commit with id " + oid + " in repositories");
+      console.log("Looking for commit with id " + oid + " in repositories.");
       return Git.AnnotatedCommit.lookup(repos, oid);
     })
     .then(function (annotated) {
-      console.log("Force merge commit " + annotates + " into HEAD");
+      console.log("Force merge commit " + annotates + " into HEAD.");
       Git.Merge.merge(repos, annotated, null, {
         checkoutStrategy: Git.Checkout.STRATEGY.FORCE,
       });
@@ -776,7 +777,7 @@ function showRebaseModal() {
   $('#rebase-modal').modal('show');
   getRebaseFromBranch();
   let branches = getEveryBranch();
-  console.log('out of method: ' + branches);
+  console.log('Out of method ' + branches);
 }
 
 function getRebaseFromBranch() {
@@ -811,24 +812,24 @@ function rebaseCommits(from: string, to: string) {
       return Git.Reference.nameToId(repos, 'refs/heads/' + from);
     })
     .then(function (oid) {
-      console.log("Looking for commit id: " + oid + " in repositories");
+      console.log("Looking for commit id: " + oid + " in repositories.");
       return Git.AnnotatedCommit.lookup(repos, oid);
     })
     .then(function (annotated) {
-      console.log("finding the id of " + annotated);
+      console.log("Finding the id of " + annotated);
       branch = annotated;
       return Git.Reference.nameToId(repos, 'refs/heads/' + to);
     })
     .then(function (oid) {
-      console.log("" + oid);
+      console.log("Oid: " + oid);
       return Git.AnnotatedCommit.lookup(repos, oid);
     })
     .then(function (annotated) {
-      console.log("Changing commit message");
+      console.log("Changing commit message.");
       return Git.Rebase.init(repos, branch, annotated, null, null);
     })
     .then(function (rebase) {
-      console.log("Rebasing");
+      console.log("Rebasing.");
       return rebase.next();
     })
     .then(function (operation) {
@@ -863,7 +864,7 @@ function resetCommit(name: string) {
       return Git.Reference.nameToId(repo, name);
     })
     .then(function (id) {
-      console.log("looking for: " + id);
+      console.log("Looking for commit" + id);
       return Git.AnnotatedCommit.lookup(repos, id);
     })
     .then(function (commit) {
@@ -871,7 +872,7 @@ function resetCommit(name: string) {
       return Git.Reset.fromAnnotated(repos, commit, Git.Reset.TYPE.HARD, checkoutOptions);
     })
     .then(function (number) {
-      console.log("resetting " + number);
+      console.log("Resetting " + number);
       if (number !== 0) {
         updateModalText("Reset failed, please check if you have pushed the commit.");
       } else {
@@ -879,6 +880,7 @@ function resetCommit(name: string) {
       }
       refreshAll(repos);
     }, function (err) {
+      console.log("ERROR while resetting commit: " + err);
       updateModalText(err);
     });
 }
@@ -904,7 +906,7 @@ function showStashModal() {
 
 function handleStashError(err) {
   // handle any errors
-  console.log("stash error!" + err)
+  console.log("ERROR while stashing: " + err + ".");
   updateModalText("Stash error: " + err.message);
 }
 
@@ -953,7 +955,7 @@ function stashChanges() {
         .then(function(oid) {
           // error for testing purposes
           //throw new Error('test error2');
-          console.log("change stashed with oid" + oid);
+          console.log("Change stashed with oid " + oid + ".");
       }).catch(function(err) {
         handleStashError(err)
       }).done(function() {
@@ -1142,14 +1144,14 @@ function revertCommit() {
   Git.Repository.open(repoFullPath)
   .then(function(Commits){
     sortedListOfCommits(Commits);
-     console.log("Commits; "+ commitHistory[0]);
+     console.log("Commits: "+ commitHistory[0]);
     })
 
     Git.Repository.open(repoFullPath)
     .then(function(repo){
       repos = repo;
       return repos;
-      console.log("This is repos "+ repos);
+      console.log("This is repos: "+ repos);
     })
     .then(function(Commits){
       let index = returnSelectedNodeValue()-1;
@@ -1174,7 +1176,7 @@ function revertCommit() {
       refreshAll(repos);
     })
     .catch(function (err) {
-      console.log(err);
+      console.log("ERROR reverting commit: " + err);
       updateModalText("Error reverting commit, please commit changes as they will be overwritten, then try again");
     })
   })
@@ -1386,7 +1388,7 @@ function displayModifiedFiles() {
 
           fileElement.onclick = function () {
             let doc = document.getElementById("diff-panel")!;
-            console.log("width of document: " + doc.style.width);
+            console.log("Width of document: " + doc.style.width);
             let fileName = document.createElement("p");
             fileName.innerHTML = file.filePath;
             // Get the filename being edited and displays on top of the window
@@ -1521,7 +1523,7 @@ function displayModifiedFiles() {
 
           fileElement.onclick = function () {
             let doc = document.getElementById("diff-panel");
-            console.log("width of document: " + doc.style.width);
+            console.log("Width of document: " + doc.style.width);
             let fileName = document.createElement("p");
             fileName.innerHTML = file.filePath
             // Get the filename being edited and displays on top of the window
@@ -1690,10 +1692,10 @@ function deleteFile(filePath: string) {
         console.log("git.ts, line 759, an error occurred updating the file " + err);
         return;
       }
-      console.log("File successfully deleted");
+      console.log("File successfully deleted.");
     });
   } else {
-    alert("This file doesn't exist, cannot delete");
+    alert("This file doesn't exist, cannot delete.");
   }
 }
 
@@ -1701,7 +1703,7 @@ function cleanRepo() {
   let fileCount = 0;
   Git.Repository.open(repoFullPath)
     .then(function (repo) {
-      console.log("Removing untracked files")
+      console.log("Removing untracked files.")
       displayModal("Removing untracked files...");
       addCommand("git clean -f");
       repo.getStatus().then(function (arrayStatusFiles) {
@@ -1712,16 +1714,16 @@ function cleanRepo() {
           let filePath = path.join(repoFullPath, file.path());
           let modification = calculateModification(file);
           if (modification === "NEW") {
-            console.log("DELETING FILE " + filePath);
+            console.log("Deleting file: " + filePath);
             deleteFile(filePath);
-            console.log("DELETION SUCCESSFUL");
+            console.log("File deletion successful.");
             fileCount++;
           }
         }
 
       })
         .then(function () {
-          console.log("Cleanup successful");
+          console.log("Cleanup successful.");
           if (fileCount !== 0) {
             updateModalText("Cleanup successful. Removed " + fileCount + " files.");
           } else {
@@ -1731,7 +1733,7 @@ function cleanRepo() {
         });
     },
       function (err) {
-        console.log("Waiting for repo to be initialised");
+        console.log("Waiting for repo to be initialised.");
         displayModal("Please select a valid repository");
       });
 }
@@ -1804,11 +1806,11 @@ function setUpstreamRepo() {
       }
       else if (error.message == "remote 'upstream' already exists"){ //Checking for existing upstream branch
         displayModal("Upstream branch already exists");
-      } 
+      }
       }), displayModal("Upstream repository successfully configured.");
     }, function(err) {
-      console.log("Error adding remote upstream repository:" + err) //Checking if a repo is opened before setting an upstream
-      displayModal("Please open a valid repository first");
+      console.log("ERROR adding remote upstream repository:" + err) //Checking if a repo is opened before setting an upstream
+      displayModal("Please open a valid repository first.");
     });
   }
   clearUpstreamModalText();
@@ -1833,16 +1835,19 @@ function syncFromFork() {
     var result = Git.Remote.addFetch(repository, 'upstream', 'remotes/upstream/master');
     return repository.fetch('upstream',fetchOptions) //fetch from upstream
   }, function (err) {
+    console.log("ERROR fetching: " + err);
     displayModal("Error fetching:"+ err)
   })
   .then(function() {
     return repository.checkoutBranch("master") //checkout master
   }, function (err) {
+    console.log("ERROR checking out branch: " + err);
     displayModal("Error checking out branch:"+ err)
   })
   .then(function() {
     return repository.mergeBranches("master", "upstream/master"); //merge upstream/master into master
   }, function (err) {
+    console.log("ERROR merging: " + err);
     displayModal("Error merging:"+ err)
   })
   .then(function(oid){
@@ -1863,11 +1868,14 @@ function moveFile(filesource:string, filedestination:string, skipFileExistTest:b
     let sGitRepo = sGit(repoFullPath);  // open repository with simple-git
     sGitRepo.silent(true)   // activate silent mode to prevent fatal errors from getting logged to STDOUT
         .mv(filesource, filedestination)  //perform GIT MV operation
-        .then(() => console.log('move completed'))
-        .catch((err) => displayModal('move failed: ' + err));
+        .then(() => console.log('File move completed.'))
+        .catch((err) => {
+          displayModal('File move failed: ' + err));
+          console.log("ERROR: file move failed. Full error: " + err);
+      }
   }
   else{
-    displayModal("Destination directory does not exist");
+    displayModal("Destination directory does not exist.");
   }
 }
 

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -777,7 +777,7 @@ function showRebaseModal() {
   $('#rebase-modal').modal('show');
   getRebaseFromBranch();
   let branches = getEveryBranch();
-  console.log('Out of method ' + branches);
+  // console.log('Out of method ' + branches);
 }
 
 function getRebaseFromBranch() {
@@ -796,7 +796,7 @@ async function getEveryBranch() {
   }
 
   let branches = await fetchBranches();
-  console.log('In method: ' + branches);
+  // console.log('In method: ' + branches);
   return branches;
 }
 

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -21,7 +21,7 @@ let vis = require("vis");
 let commitHistory = [];
 let commitToRevert = 0;
 let commitHead = 0;
-let commitID = 0;x
+let commitID = 0;
 let lastCommitLength;
 let refreshAllFlagCommit = false;
 

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -217,7 +217,7 @@ function addAndCommit() {
 
       refreshAll(repository);
     }, function (err) {
-      console.log("git.ts, line 112, could not commit, " + err);
+      console.log("ERROR: could not commit  " + err);
       // Added error thrown for if files not selected
       if (err.message == "No files selected to commit.") {
         displayModal(err.message);
@@ -341,7 +341,7 @@ function getAllCommits(callback) {
         },
 
         function (err) {
-          console.log("git.ts, line 203, cannot load all commits" + err);
+          console.log("ERROR: cannot load all commits: " + err + ".");
           callback(allCommits);
         });
     });
@@ -522,7 +522,7 @@ function createBranch() {
               getSignature(repo),
               "Created new-branch on HEAD");
           }, function (err) {
-            console.log("git.ts, line 337, error occurred while trying to create a new branch " + err);
+            console.log("ERROR occurred while trying to create a new branch " + err);
           });
       }).done(function () {
         $('#branch-modal').modal('hide');
@@ -1689,7 +1689,7 @@ function deleteFile(filePath: string) {
     fs.unlink(newFilePath, (err) => {
       if (err) {
         alert("An error occurred updating the file" + err.message);
-        console.log("git.ts, line 759, an error occurred updating the file " + err);
+        console.log("ERROR occurred updating the file " + err);
         return;
       }
       console.log("File successfully deleted.");

--- a/app/misc/graphSetup.ts
+++ b/app/misc/graphSetup.ts
@@ -8,7 +8,7 @@ let options, bsNodes, bsEdges, nodes, edges, network;
 let secP = null, fromNode = null, toNode;
 
 let GraphNodeID = 0;
- 
+
 function returnSelectedNodeValue():number{
     let returnValue = GraphNodeID;
     GraphNodeID = 0;
@@ -16,7 +16,7 @@ function returnSelectedNodeValue():number{
 }
 
 function drawGraph() {
-    updateGraphProgress(0);    
+    updateGraphProgress(0);
     document.getElementById('graph-loading').style.display = 'block';
     $('#modal').modal('show');
     bsNodes = new vis.DataSet([]);
@@ -147,27 +147,27 @@ function drawGraph() {
         aheadCommitList=[]
         let sGitRepo = sGit(repoFullPath);
         sGitRepo.silent( true ).log( { '--branches': null, '--not': null, '--remotes': null } ).then( ( result ) =>
-        {  
+        {
             //collect all branches unpush commits using:- git log --branches --not --remotes
             for ( let k = 0; k < result.all.length; k++ )
             {
                 aheadCommitList.push( result.all[ k ].hash );
             }
         } ).then(() => sGitRepo.silent( true ).log( { 'origin/master..master': null } )).then(( result ) =>
-        {  
+        {
             //add unpush commit on master using:- git log origin/master..master
             for ( let k = 0; k < result.all.length; k++ )
             {
                 aheadCommitList.push( result.all[ k ].hash );
             }
         }).catch(function (err) {
-            console.log("ERROR!! unable to load local Only commits becuase: "+err.message);
+            console.log("ERROR: unable to load local only commits because: "+err.message);
         } ).then( function (){
             processGraph( commits );
-        } ).catch( function ( err ){ 
-            console.log(err)
+        } ).catch( function ( err ){
+            console.log("ERROR loading local commits: " + err)
         } );
-        
+
 
         network.on("stabilizationIterationsDone", function () {
             network.setOptions({physics: false});
@@ -275,7 +275,7 @@ function drawGraph() {
                 }
             }
         })
-        
+
         // Clicking on the network disables the context menu
         network.on("click", function (properties) {
             let contextMenu = $("#networkContext")
@@ -351,7 +351,8 @@ function displaySelectedCommitDiffPanel(commitId): void {
       closeButton.style.display = "inline";
     }
     let commitPanel = document.getElementById("selected-commit-diff-panel");
-    console.log("inside display selected commit");
+    // To help with understanding order of operations:
+    // console.log("Inside display selected commit.");
     if (commitPanel != null) {
       commitPanel.style.height = "100vh";
       commitPanel.style.width = "100vw";

--- a/app/misc/graphing.ts
+++ b/app/misc/graphing.ts
@@ -43,7 +43,7 @@ Types of nodes in the network.
     Tag = Represents a tag reference. Is linked to a single commit node
 */
 
-/* 
+/*
 Types of nodes in the network.
     Basic = Commit node in the highest zoom level (1st level). Represents a collection of commits
     Node = Commit node in the lowest zoom level (2rd level). Represents a a single commit
@@ -69,12 +69,12 @@ function generateUniqueNumber() {
 
 // Process and populate the initial graph
 function processGraph(commits: nodegit.Commit[]) {
-    
+
     var promise = new Promise(function(resolve,reject){
         commitHistory = [];
         basicList = [];
         numOfCommits = commits.length;
-        
+
         sortCommits(commits)
             .then(populateCommits)
             .then(function(data) {
@@ -82,7 +82,7 @@ function processGraph(commits: nodegit.Commit[]) {
                 if (textBox != null) {
                         document.getElementById('graph-loading').style.display = 'none';
                     } else {
-                        console.log("Modal-text-box is missing");
+                        console.log("ERROR: Modal-text-box is missing.");
                     }
                 });
     });
@@ -92,8 +92,8 @@ function processGraph(commits: nodegit.Commit[]) {
 // Sort the commit nodes in order to better populate the graph
 function sortCommits(commits) {
     var promise = new Promise((resolve, reject) => {
-        let stageStartProgress = 0; 
-        let stageEndProgress = 80; 
+        let stageStartProgress = 0;
+        let stageEndProgress = 80;
 
         updateGraphProgress(stageStartProgress);
 
@@ -102,9 +102,9 @@ function sortCommits(commits) {
 
         function computeChunk() {
             var count = chunk;
-            
+
             while (commits.length > 0 && count--) {
-                updateGraphProgress((commitHistory.length / numCommits) * stageEndProgress);  
+                updateGraphProgress((commitHistory.length / numCommits) * stageEndProgress);
 
                 let commit = commits.shift();
                 let parents = commit.parents();
@@ -146,10 +146,10 @@ function sortCommits(commits) {
 
 // Populate the graph nodes and add edges where appropriate
 function populateCommits(oldResult) {
-    let stageStartProgress = 80; 
-    let stageEndProgress = 100; 
+    let stageStartProgress = 80;
+    let stageEndProgress = 100;
 
-    updateGraphProgress(stageStartProgress);    
+    updateGraphProgress(stageStartProgress);
 
     var promise = new Promise((resolve, reject) => {
         // reset variables for idempotency, shouldn't be needed when a class is created instead
@@ -160,10 +160,10 @@ function populateCommits(oldResult) {
         columns = [];
         branchIds = [];
         tagIds = [];
-        
+
         // Plot the graph
         for (let i = 0; i < commitHistory.length; i++) {
-            updateGraphProgress((i / commitHistory.length) * stageEndProgress);  
+            updateGraphProgress((i / commitHistory.length) * stageEndProgress);
 
             let parents: string[] = commitHistory[i].parents();
             let nodeColumn;
@@ -241,9 +241,9 @@ function populateCommits(oldResult) {
         for (let i = 0; i < basicList.length; i++) {
             addBasicEdge(basicList[i]);
         }
-        
+
         //sortBasicGraph();
-        
+
         updateGraphProgress(stageEndProgress);
 
         commitList = commitList.sort(timeCompare);
@@ -357,7 +357,7 @@ function makeBasicNode(c, column: number, isUnpushCommit: boolean) {
 
     if (flag) {
         id = basicNodeId++;
-        let title = "Author: " + name + "<br>" + "Number of Commits: " + count;
+        let title = "Author: " + name + " || " + "Number of Commits: " + count;
         console.log(title);
         let imageUrl;
         let colorData = {};
@@ -405,7 +405,7 @@ function makeBasicNode(c, column: number, isUnpushCommit: boolean) {
                 author: c.author(),
                 nodeType: NodeType.Basic
             });
-        });   
+        });
 
         // Update node list
         let shaList = [];
@@ -429,7 +429,7 @@ function makeBasicNode(c, column: number, isUnpushCommit: boolean) {
             let branchName = bname[c.toString()][i];
             let bp = branchName.name().split("/");
             let shortName = bp[bp.length - 1];
-            console.log(shortName + " sub-branch: " + branchName.isHead().toString());
+            // console.log(shortName + " sub-branch: " + branchName.isHead().toString());
             if (branchName.isHead()) {
                 shortName = "*" + shortName;
             }
@@ -469,7 +469,7 @@ function makeBasicNode(c, column: number, isUnpushCommit: boolean) {
             let tagName = tags[c.toString()][i];
             let tp = tagName.name().split("/");
             let shortTagName = tp[tp.length - 1];
-            console.log(shortTagName + " tag: " + tagName.isHead().toString());
+            // console.log(shortTagName + " tag: " + tagName.isHead().toString());
             if (tagName.isHead()) {
                 shortTagName = "*" + shortTagName;
             }
@@ -531,7 +531,7 @@ function makeNode(c, column: number, isUnpushCommit : boolean) {
     }
 
     let flag = false;
-  
+
     let colorData = {}
     if ( isUnpushCommit )
     {
@@ -545,7 +545,7 @@ function makeNode(c, column: number, isUnpushCommit : boolean) {
             }
         }
     }
-    
+
     nodes.add({
         id: id,
         shape: "circularImage",
@@ -567,7 +567,7 @@ function makeNode(c, column: number, isUnpushCommit : boolean) {
             let branchName = bname[c.toString()][i];
             let bp = branchName.name().split("/");
             let shortName = bp[bp.length - 1]; // Get the branch's name instead of ref/origin/branch
-            console.log(shortName + " sub-branch: " + branchName.isHead().toString());
+            // console.log(shortName + " sub-branch: " + branchName.isHead().toString());
             if (branchName.isHead()) {
                 shortName = "*" + shortName;
             }
@@ -610,7 +610,7 @@ function makeNode(c, column: number, isUnpushCommit : boolean) {
             let tagName = tags[c.toString()][i];
             let tp = tagName.name().split("/");
             let shortTagName = tp[tp.length - 1]; // Get the tag's name instead of ref/origin/tag
-            console.log(shortTagName + " tag: " + tagName.isHead().toString());
+            // console.log(shortTagName + " tag: " + tagName.isHead().toString());
             if (tagName.isHead()) {
                 shortTagName = "*" + shortTagName;
             }

--- a/app/misc/images.ts
+++ b/app/misc/images.ts
@@ -5,7 +5,7 @@ let images = {};
 
 /**
  * Helper function for getting the letter icon for a given author.
- * 
+ *
  * @param name Name of the commit's author
  * @returns filepath for the picture containing the author's first initial
  */
@@ -19,24 +19,24 @@ function getName(author: string) {
   return name;
 }
 
-// No longer in use, but keeping it here in case of any potential 
+// No longer in use, but keeping it here in case of any potential
 // backward-compatibility issues on other VisualGit branches.
-function img4User(name:string) {  
+function img4User(name:string) {
   return getLetterIcon(name);
 }
 
 /** Retreives the URL for the given author's GitHub profile picture.*/
 function imageForUser(name: string, email: string, callback) {
-  
-  let pic;  
-  
+
+  let pic;
+
   if (email.includes('@users.noreply.github.com')) {
-    
+
     // Extract GitHub username from noreply email (<number>+<username>@users.noreply.github.com)
     // This won't work for users that are NOT hiding their email in the GitHub settings.
     // See https://help.github.com/en/articles/about-commit-email-addresses for more info.
     let username = email.replace('@users.noreply.github.com','').replace(/^(\d){4,}\+/,'');
-    
+
     // try the local cache first
     pic = images[username];
     if (typeof(pic) !== "undefined") {
@@ -44,23 +44,23 @@ function imageForUser(name: string, email: string, callback) {
       callback(pic);
     }
     else {
-      // github-avatar-url insists on having an API token, 
+      // github-avatar-url insists on having an API token,
       // but since we're don't need it for public info, we'll instead use octonode to avoid having said token.
       // That being said, if you've hit the rate limit, just supply the token below; i.e. gh.client('token')
       let client = gh.client();
-      
+
       let t = client.get(`/users/${username}`, {}, function (err, status, body, headers) {
-        if (!err) {          
+        if (!err) {
           pic = body.avatar_url;
           images[username] = pic;   // add to cache
           console.log(`GitHub API: ${pic}`)
-        }        
+        }
         else {
-          console.log(`GitHub API: ${err}`);
+          console.log(`ERROR: GitHub API: ${err}`);
           console.log("GitHub API request failed; using letter icons instead");
 
           pic = getLetterIcon(name);
-        }        
+        }
         callback(pic);
       });
     }

--- a/app/misc/repo.ts
+++ b/app/misc/repo.ts
@@ -62,7 +62,7 @@ function saveRecentRepositories(repoPath) {
       jsonfile.writeFileSync(repoFile, updatedRepoList);
     } catch (err) {
       let recentRepoError = err;
-      console.log("ERROR saving recent repository list. saveRecentRepositories() in repo.ts threw the error: " + recentRepoError);
+      console.log("ERROR saving recent repository list: " + recentRepoError);
     }
 }
 
@@ -162,7 +162,7 @@ function downloadFunc(cloneURL, fullLocalPath) {
     },
       function (err) {
         updateModalText("Clone Failed - " + err);
-        console.log("repo.ts, line 64, failed to clone repo: " + err); // TODO show error on screen
+        console.log("ERROR failed to clone repo: " + err); // TODO show error on screen
         switchToAddRepositoryPanel();
       });
 }
@@ -270,7 +270,7 @@ function openRepository() {
     },
       function (err) {
         updateModalText("No repository found. Select a folder with a repository.");
-        console.log("repo.ts, line 101, cannot open repository: " + err); // TODO show error on screen
+        console.log("ERROR: cannot open repository: " + err); // TODO show error on screen
         switchToAddRepositoryPanel();
       });
     document.getElementById("dirPickerOpenLocal").value = "";
@@ -320,7 +320,7 @@ function openRepository() {
       },
         function (err) {
           updateModalText("Creating Failed - " + err);
-          //console.log("repo.ts, line 131, cannot open repository: "+err); // TODO show error on screen
+          //console.log("ERROR cannot open repository: "+err); // TODO show error on screen
         });
     }
 
@@ -423,7 +423,7 @@ function refreshReferences(verbose, force) {
                 console.log("Unsupported reference: " + refList[i].name());
               }
             }, function (err) {
-              console.log("repo.ts, line 269, could not find referenced branch" + err);
+              console.log("ERROR: could not find referenced branch" + err);
             });
 
             // display branch list and tag list
@@ -798,7 +798,7 @@ function refreshReferences(verbose, force) {
           .then(function () {
             refreshAll(repo);
           }, function (err) {
-            console.log("repo.ts, line 271, cannot checkout local branch: " + err);
+            console.log("ERROR: cannot checkout local branch: " + err);
           });
       })
   }
@@ -841,7 +841,7 @@ function refreshReferences(verbose, force) {
             console.log("Pull successful.");
           });
       }, function (err) {
-        console.log("repo.ts, line 306, could not pull from repository" + err);
+        console.log("ERROR: could not pull from repository" + err);
       })
   }
 

--- a/app/misc/repo.ts
+++ b/app/misc/repo.ts
@@ -26,7 +26,7 @@ function getRecentRepositories() {
     try {
         repoList = JSON.parse(checkFile.readFileSync(repoFile));
     } catch (err) {
-        console.log('Cannot read ' + repoFile);
+        console.log('ERROR: Cannot read file: ' + repoFile);
         repoList = {
             recentRepos: []
         }
@@ -47,13 +47,13 @@ function saveRecentRepositories(repoPath) {
     try {
         repoList = JSON.parse(checkFile.readFileSync(repoFile));
     } catch (err) {
-        console.log('Cannot read ' + repoFile);
+        console.log('ERROR: Cannot read file ' + repoFile);
         repoList = {
             recentRepos: []
         }
     }
 
-    console.log('Updating recent repos');
+    console.log('Updating recent repos.');
     updatedRepoList = {
         recentRepos: updateRecentRepos(repoList.recentRepos, repoPath)
     }
@@ -61,7 +61,8 @@ function saveRecentRepositories(repoPath) {
     try {
       jsonfile.writeFileSync(repoFile, updatedRepoList);
     } catch (err) {
-      console.log(err);
+      let recentRepoError = err;
+      console.log("ERROR saving recent repository list. saveRecentRepositories() in repo.ts threw the error: " + recentRepoError);
     }
 }
 
@@ -85,7 +86,7 @@ function updateRecentRepos(recentRepos, repoToAdd) {
     recentRepos.push(repoToAdd);
 
     if (recentRepos.length > maxRepos) {
-        console.log('Removing head of list')
+        console.log('Removing head of list.')
         recentRepos.splice(0, 1);
     }
     return recentRepos;
@@ -102,7 +103,7 @@ function downloadRepository() {
   } else {
 
     fullLocalPath = document.getElementById("dirPickerSaveNew").files[0].path;
-    console.log(repoFullPath)
+    console.log("Full repo path: " + repoFullPath);
 
   }
 
@@ -143,12 +144,12 @@ function downloadFunc(cloneURL, fullLocalPath) {
     }
   };
 
-  console.log("cloning into " + fullLocalPath);
+  console.log("Cloning into " + fullLocalPath);
   let repository = Git.Clone.clone(cloneURL, fullLocalPath, options)
     .then(function (repository) {
       progressDiv.style.visibility = 'collapse';
       updateProgressBar(0);
-      console.log("Repo successfully cloned");
+      console.log("Repo successfully cloned.");
       document.getElementById('graph-loading').style.display = 'block';
       refreshAll(repository);
       updateModalText("Clone Successful, repository saved under: " + fullLocalPath);
@@ -174,7 +175,7 @@ function updateProgressBar(ratio) {
 }
 
 function openRepository() {
-  console.log("Open Repository")
+  console.log("Opening Repository...")
   if (document.getElementById("dirPickerOpenLocal").value === previousOpen && previousOpen != undefined) {
     return;
   }
@@ -199,7 +200,7 @@ function openRepository() {
       }
     }
 
-    console.log('Saving repository path');
+    console.log('Saving repository path...');
     saveRecentRepositories(fullLocalPath);
 
     console.log("Trying to open repository at " + fullLocalPath);
@@ -210,7 +211,7 @@ function openRepository() {
       repoLocalPath = localPath;
       if (readFile.exists(repoFullPath + "/.git/MERGE_HEAD")) {
         let tid = readFile.read(repoFullPath + "/.git/MERGE_HEAD", null);
-        console.log("current HEAD commit: " + tid);
+        console.log("Current HEAD commit: " + tid);
       }
       //Reads the git config file and extracts info about the remote "origin" branch on GitHub
       if (readFile.exists(repoFullPath + "/.git/config")) {
@@ -264,8 +265,8 @@ function openRepository() {
       }
       document.getElementById('graph-loading').style.display = 'block';
       refreshAll(repository);
-      console.log("Repo successfully opened");
-      updateModalText("Repository successfully opened");
+      console.log("Repo successfully opened.");
+      updateModalText("Repository successfully opened.");
     },
       function (err) {
         updateModalText("No repository found. Select a folder with a repository.");
@@ -332,7 +333,7 @@ function openRepository() {
     elem.innerHTML = '';
     for (let i = 0; i < localBranches.length; i++) {
       if (localBranches[i] !== thisB) {
-        console.log("local branch: " + localBranches[i]);
+        console.log("Local branch is: " + localBranches[i]);
         let li = document.createElement("li");
         let a = document.createElement("a");
         a.appendChild(document.createTextNode(localBranches[i]));
@@ -370,7 +371,7 @@ function refreshReferences(verbose, force) {
           }
 
           // detects changes, refresh the lists
-          console.log("branch or tag changes detected... refreshing branch and tag list");
+          console.log("Branch or tag changes detected... refreshing branch and tag list.");
 
           if (!refreshAllFlagRef) {
             // show refresh graph alert
@@ -387,7 +388,7 @@ function refreshReferences(verbose, force) {
           tags = {};
           clearBranchAndTagElement();
           for (let i = 0; i < refList.length; i++) {
-            if (verbose) { console.log("reference name: " + refList[i].name()); }
+            if (verbose) { console.log("Reference name: " + refList[i].name()); }
             //get simplified name
             let refName = refList[i].name().split("/")[refList[i].name().split("/").length - 1];
 
@@ -436,7 +437,7 @@ function refreshReferences(verbose, force) {
             } else if (refList[i].isTag()){
               displayTag(refName, "tag-item-list", ""); // TODO: support switching to a tag by adding an on-click function
             } else{
-              console.log("Unsupported reference: " + refList[i].name());
+              console.log("ERROR: Unsupported reference: " + refList[i].name());
             }
           }
           // update lastRefList
@@ -455,7 +456,7 @@ function refreshReferences(verbose, force) {
       .then(function (reference) {
         //Get the simplified name from the branch
         let branchParts = reference.name().split("/");
-        console.log("branch parts: " + branchParts);
+        console.log("Branch parts: " + branchParts);
         branch = branchParts[branchParts.length - 1];
       })
       .then(function () {
@@ -466,7 +467,7 @@ function refreshReferences(verbose, force) {
         checkCommitChange();
       })
       .then(function () {
-        console.log("Updating the graph and the labels");
+        console.log("Updating the graph and the labels.");
         drawGraph();
         let breakStringFrom;
         if (repoLocalPath.length > 20) {
@@ -486,8 +487,8 @@ function refreshReferences(verbose, force) {
         window.alert("Warning:\n" +
           "No branches have been found in this repository.\n" +
           "This is likely because there have been no commits made.");
-        console.log("No branches found. Setting default label values to master");
-        console.log("Updating the labels and graph");
+        console.log("No branches found. Setting default label values to master.");
+        console.log("Updating the labels and graph.");
         drawGraph();
         document.getElementById("repo-name").innerHTML = repoLocalPath;
         //default label set to master
@@ -507,14 +508,14 @@ function refreshReferences(verbose, force) {
       .then(function (branchList) {
         clearBranchAndTagElement();
         for (let i = 0; i < branchList.length; i++) {
-          console.log("branch discovered: " + branchList[i]);
+          console.log("Branch discovered: " + branchList[i]);
           let bp = branchList[i].split("/");
           if (bp[1] !== "remotes") {
             displayBranch(bp[bp.length - 1], "branch-dropdown", "checkoutLocalBranch(this)");
           }
           Git.Reference.nameToId(repos, branchList[i]).then(function (oid) {
             // Use oid
-            console.log("old id " + oid);
+            console.log("Oid " + oid);
           });
         }
       });
@@ -537,7 +538,7 @@ function refreshReferences(verbose, force) {
       })
       .then(function (ref) {
         let name = ref.name().split("/");
-        console.log("merging remote branch with tracked local branch");
+        console.log("Merging remote branch with tracked local branch.");
         clearBranchAndTagElement();
         for (let i = 0; i < list.length; i++) {
           let bp = list[i].split("/");
@@ -788,7 +789,7 @@ function refreshReferences(verbose, force) {
         bn = bn.substr(0, bn.lastIndexOf(img)) // remove remote branch <img> tag from branch name string
       }
     }
-    console.log("name of branch being checked out: " + bn);
+    console.log("Name of branch being checked out: " + bn);
     Git.Repository.open(repoFullPath)
       .then(function (repo) {
         document.getElementById('graph-loading').style.display = 'block';
@@ -797,7 +798,7 @@ function refreshReferences(verbose, force) {
           .then(function () {
             refreshAll(repo);
           }, function (err) {
-            console.log("repo.tx, line 271, cannot checkout local branch: " + err);
+            console.log("repo.ts, line 271, cannot checkout local branch: " + err);
           });
       })
   }
@@ -816,7 +817,7 @@ function refreshReferences(verbose, force) {
         bn = bn.substr(0, bn.lastIndexOf(img))  // remove local branch <img> tag from branch name string
       }
     }
-    console.log("current branch name: " + bn);
+    console.log("Current branch name: " + bn);
     let repos;
     Git.Repository.open(repoFullPath)
       .then(function (repo) {
@@ -824,20 +825,20 @@ function refreshReferences(verbose, force) {
         addCommand("git fetch");
         addCommand("git checkout -b " + bn);
         let cid = remoteName[bn];
-        console.log("name of remote branch:  " + cid);
+        console.log("Name of remote branch:  " + cid);
         return Git.Commit.lookup(repo, cid);
       })
       .then(function (commit) {
-        console.log("commiting");
+        console.log("Commiting...");
         return Git.Branch.create(repos, bn, commit, 0);
       })
       .then(function (code) {
-        console.log("name of local branch " + bn);
+        console.log("Local branch: " + bn);
         repos.mergeBranches(bn, "origin/" + bn)
           .then(function () {
             document.getElementById('graph-loading').style.display = 'block';
             refreshAll(repos);
-            console.log("Pull successful");
+            console.log("Pull successful.");
           });
       }, function (err) {
         console.log("repo.ts, line 306, could not pull from repository" + err);

--- a/app/misc/router.ts
+++ b/app/misc/router.ts
@@ -13,7 +13,7 @@ function collapseSignPanel() {
 }
 
 function switchToClonePanel() {
-  console.log("switch to clone panel");
+  console.log("Switching to clone panel");
   hideAuthenticatePanel();
   hideFilePanel();
   hidePullRequestPanel();
@@ -46,7 +46,7 @@ function switchToMainPanel() {
 
 function checkSignedIn() {
   if (continuedWithoutSignIn) {
-    displayModal("You need to sign in");
+    displayModal("Sign in required, please sign in.");
     // Don't open the repo modal
     $('#repo-name').removeAttr("data-target");
 } else {
@@ -74,7 +74,7 @@ function switchToAddRepositoryPanelWhenNotSignedIn() {
 
 function switchToAddRepositoryPanel() {
   inTheApp = true
-  console.log("Switching to add repo panel");
+  console.log("Switching to add repo panel.");
   useRecentRepositories();
   hideFooter();
   hideAuthenticatePanel();
@@ -116,10 +116,10 @@ function wait(ms) {
 }
 
 function displayUsername() {
-  console.log("Display Username called");
   document.getElementById("Button_Sign_out").style.display = "block";
   showUsername = true;
-  console.log(getUsername());
+  let currentUsername = getUsername();
+  console.log("Currently signed in as: " + currentUsername);
   let githubname = document.getElementById("githubname");
   if (githubname != null){
     let existing_username = githubname.innerHTML;
@@ -349,7 +349,7 @@ function useSavedCredentials() : boolean {
   let file = 'data.json';
   // check if the data.json file exists
   if (fs.existsSync(file)) {
-    console.log('button has been pressed: logging in with saved credentials');
+    console.log('Previous login detected: logging in with saved credentials...');
     decrypt();
     loginWithSaved(switchToMainPanel);
     return true;
@@ -364,7 +364,7 @@ function createRecentRepositories(file) {
     try {
         fs.writeFileSync(file);
     } catch (err) {
-        console.log(err);
+        console.log("ERROR Could not create recent repository file, createRecentRepositories() in router.ts threw error: " + err);
     }
 }
 
@@ -374,9 +374,9 @@ function useRecentRepositories() {
     let file = 'repos.json';
 
     if (!fs.existsSync(file)) {
-        console.log(file + ' does not exist');
+        console.log("ERROR: " + file + ' does not exist.');
         createRecentRepositories(file);
     } else {
-        console.log(file + ' exists')
+        console.log(file + ' exists.')
     }
 }

--- a/app/misc/storeCredentials.ts
+++ b/app/misc/storeCredentials.ts
@@ -10,7 +10,7 @@ function encryptAccessToken(accessToken) {
 
   jsonfile.writeFile(file, obj, function (err) {
     if (err) throw err;
-    console.log('Access Token Saved to File System');
+    console.log('Access Token Saved to File System.');
 
   })
 }
@@ -20,7 +20,7 @@ function getAccessToken(){
   // If user is not logged in, return null
   if (!!!encryptedToken)
     return null
-  // Decrypt the access token to 
+  // Decrypt the access token to
   var bytes = CryptoJS.AES.decrypt(encryptedToken.toString(), os.hostname());
   return bytes.toString(CryptoJS.enc.Utf8);
 }
@@ -29,6 +29,3 @@ function getAccessToken(){
 function encryptTemp(token) {
   encryptedToken = CryptoJS.AES.encrypt(token, os.hostname());
 }
-
-
-

--- a/app/misc/wiki.ts
+++ b/app/misc/wiki.ts
@@ -19,7 +19,7 @@ function openWiki() {
     wikis.style.height = "100vh";
     wikis.style.zIndex = "15";
 
-    console.log(repoFullPath);
+    console.log("Full repo path: " + repoFullPath);
     if (!fs.existsSync(repoFullPath + "\\wiki")) {
         cloneWiki();
     } else {
@@ -27,8 +27,9 @@ function openWiki() {
     }
 
     let externalLinkButton = document.getElementById("wikiLinkButton")!;
+    console.log("Getting wiki url: ");
     console.log(getWikiUrl()!);
-    externalLinkButton.setAttribute("href", getWikiUrl()! + "/wiki"); 
+    externalLinkButton.setAttribute("href", getWikiUrl()! + "/wiki");
 }
 
 function cloneWiki() {
@@ -51,10 +52,10 @@ function cloneWiki() {
     console.log("The wiki path is: ", wikiPath);
     let repository = Git.Clone.clone(cloneUrl, wikiPath, options)
         .then(function (repository) {
-            console.log("Wiki successfully cloned")
+            console.log("Wiki successfully cloned.")
 
             findPageNames(wikiPath, displayWiki)
-            
+
         }, function (err) {
             updateModalText("Clone Failed. Wiki does not exist for this repository or you do not have permission to access the wiki. ");
             console.log("repo.ts, line 64, failed to clone repo: " + err); // TODO show error on screen
@@ -97,7 +98,7 @@ function readFileContents(wikiDirectory: string) {
 function displayWiki() : void {
     let marked = require('marked');
     let wiki_page_counter = 0;
-    
+
     let wiki_content = document.getElementById("wiki-content")!;
     while (wiki_content.firstChild){
         wiki_content.removeChild(wiki_content.firstChild);
@@ -130,7 +131,7 @@ function displayWiki() : void {
         let content_body = document.createElement("div");
         content_body.className = "content-body";
         content_body.innerHTML = marked(page.pageContent);
-        
+
         wiki_content_template.appendChild(content_body);
         wiki_titles.appendChild(wiki_content_template);*/
     });
@@ -143,9 +144,9 @@ function updateWiki() {
     Git.Repository.open(localWikiPath)
         .then(function (repo) {
             repository = repo;
-            console.log("Pulling new changes from the remote repository");
+            console.log("Pulling new changes from the remote repository.");
             addCommand("git pull");
-            displayModal("Pulling new changes from the remote repository");
+            displayModal("Pulling new changes from the remote repository.");
 
             return repository.fetchAll({
                 callbacks: {
@@ -157,20 +158,20 @@ function updateWiki() {
                     }
                 }
             });
-        })  
+        })
         // Now that we're finished fetching, go ahead and merge our local branch
         // with the new one
         .then(function() {
           return Git.Reference.nameToId(repository, "refs/remotes/origin/master");
         })
         .then(function(oid) {
-          console.log("Looking up commit with id " + oid + " in all wiki repositories");
+          console.log("Looking up commit with id " + oid + " in all wiki repositories.");
           return Git.AnnotatedCommit.lookup(repository, oid);
         }, function(err) {
-          console.log("Error is " + err);
+          console.log("ERROR looking up commit id(s) in wiki repositories: " + err);
         })
         .then(function(annotated) {
-          console.log("merging " + annotated + "with local forcefully");
+          console.log("Merging " + annotated + " with local forcefully.");
           Git.Merge.merge(repository, annotated, null, {
             checkoutStrategy: Git.Checkout.STRATEGY.FORCE,
           });
@@ -184,7 +185,7 @@ function getWikiUrl(){
     if (readFile.exists(repoFullPath + "/.git/config")) {
         let gitConfigFileText = readFile.read(repoFullPath + "/.git/config", null);
         let searchString = "[remote \"origin\"]";
-        
+
         gitConfigFileText = gitConfigFileText.substr(gitConfigFileText.indexOf(searchString) + searchString.length, gitConfigFileText.length)
         gitConfigFileText = gitConfigFileText.substr(gitConfigFileText.indexOf("url = "), gitConfigFileText.lastIndexOf("."))
         gitConfigFileText = gitConfigFileText.replace(/ /g,"")
@@ -194,21 +195,21 @@ function getWikiUrl(){
         if(gitConfigFileText.includes(".g")){
             gitConfigFileText = gitConfigFileText.replace(".g","");
         }
-        
+
         let gitConfigFileSubstrings = gitConfigFileText.split('/');
-        
+
 
         //If the remote branch was set up using ssh, separate the elements between colons"
         if (gitConfigFileSubstrings[0].indexOf("@") != -1) {
           gitConfigFileSubstrings[0] = gitConfigFileSubstrings[0].substring(gitConfigFileSubstrings[0].indexOf(":") + 1);
         }
-        
+
         let owner = gitConfigFileSubstrings[gitConfigFileSubstrings.length - 2]
         let nameOfRepository = gitConfigFileSubstrings[gitConfigFileSubstrings.length - 1]
 
         var wikiUrl = "https://github.com/" + owner + "/" + nameOfRepository;
-    
+
         return wikiUrl;
-        
+
     }
 }

--- a/app/misc/wiki.ts
+++ b/app/misc/wiki.ts
@@ -58,7 +58,7 @@ function cloneWiki() {
 
         }, function (err) {
             updateModalText("Clone Failed. Wiki does not exist for this repository or you do not have permission to access the wiki. ");
-            console.log("repo.ts, line 64, failed to clone repo: " + err); // TODO show error on screen
+            console.log("ERROR in repo.ts: failed to clone repo: " + err); // TODO show error on screen
             switchToAddRepositoryPanel();
         }
         );

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@ document.addEventListener('DOMContentLoaded', function() {
   setTimeout(function() {
     // Add click event to Commit button
     document.getElementById('commit-button').addEventListener("click", function() {
-      console.log("commit button has been clicked");
+      console.log("Commit button has been clicked.");
       addAndCommit();
     });
 
@@ -113,7 +113,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
 
 $('#repo-modal').on('hidden.bs.modal', function (e) {
-  console.log(e+"Disabling clone button");
+  console.log(e+" Disabling clone button.");
   var butt = document.getElementById("cloneButton");
   butt.innerHTML = 'Clone';
   butt.setAttribute('class', 'btn btn-primary disabled');
@@ -131,7 +131,7 @@ $('#repo-modal').on('hidden.bs.modal', function (e) {
            icon: "edit",
            callback: function(itemKey, opt) {
              let content = $trigger.text();
-             console.log("path of local repository: " + repoFullPath + "/" + content);
+             console.log("Path of local repository: " + repoFullPath + "/" + content);
              let doc = document.getElementById("diff-panel-body");
              doc.innerHTML = "";
              doc.contentEditable = "true";
@@ -154,7 +154,7 @@ $.contextMenu({
     let branch;
     var options = {
       callback: function(key, options) {
-        var m = "clicked: " + key;
+        var m = "Clicked: " + key;
         console.log(m);
       },
       items: {
@@ -192,7 +192,7 @@ $.contextMenu({
         branch = branch.substring(1, branch.length);
       }
       options.items['merge to HEAD'].callback = function(itemKey, opt) {
-        console.log("meging to HEAD");
+        console.log("Merging to HEAD.");
         mergeInMenu(branch);
       };
     } else {


### PR DESCRIPTION
This PR solves #176 , the specified line codes seem to have been a legacy issue and long out of date. The hard coded line numbers have been removed, and the error is printed to the debugging console - it will be up to future developers to trace the issue themselves if that error is ever thrown. 

This PR also solves #4 as I found the culprits for the repeated printing of the unnecessary log and have commented them out with an additional comment above them if future devs want to use those for debugging.

I also commented out the repetitive `url of repo` log, this console line was overwhelming at times if the user has copious amounts of repos associated with their username. Again, a comment was added to inform future dev's of this choice. While this solves the pictured issue in #20 it does **NOT** resolve that issue - with all the console logs of the graph, that feature is still highly recommended.

Finally, I combed through the console messages to update them for grammatical consistency, punctuation, clarity, and standardized error printing to include a descriptive error comment before printing out the error log. Each error now reads `ERROR` in capital letters for easier viewing in the debugging console when an error is thrown.

When reviewing this PR please ensure that none of the functionality that you've implemented has been broken by the addition of console logs. I doubt it would be, but I just want to make sure.