### PR TITLE
Fixed issue where user is redirected to the wrong page after logging …

### DIFF
--- a/app/misc/router.ts
+++ b/app/misc/router.ts
@@ -351,7 +351,7 @@ function useSavedCredentials() : boolean {
   if (fs.existsSync(file)) {
     console.log('button has been pressed: logging in with saved credentials');
     decrypt();
-    loginWithSaved(switchToMainPanel);
+    loginWithSaved(switchToAddRepositoryPanel);
     return true;
   }
   return false;


### PR DESCRIPTION
Previously the `loginWithSaved()` function located in `authenticate.ts` had the callback `switchToMainPanel`. This has now been updated so the callback passed to `loginWithSaved()` is the `switchToAddRepository()` function.