### PR TITLE
Feature 186 drag/drop to commit

### DIFF
--- a/app/components/footer/footer.component.html
+++ b/app/components/footer/footer.component.html
@@ -1,8 +1,8 @@
 <div class="footer" id="footer">
     <div class="container-fluid" style="width: 100%;">
         <div class="row">
-            <div class="commit-panel col-sm-3" id="commit-panel">
-                <textarea placeholder="Commit disabled...&#10;&#10;No Files Staged" disabled rows=3 class="form-control" id="commit-message-input" draggable="true" onkeypress="commitShortcut(event)" ondragstart="handleCommitBoxDragStart(event)" ondragend="handleCommitBoxDragEnd(event)"></textarea>
+            <div class="commit-panel col-sm-3" id="commit-panel" draggable="false" ondragstart="handleCommitBoxDragStart(event)" ondragend="handleCommitBoxDragEnd(event)">
+                <textarea placeholder="Commit disabled...&#10;&#10;No Files Staged" disabled rows=3 class="form-control" id="commit-message-input"  onkeypress="commitShortcut(event)"></textarea>
                 <button class="input-group-addon commit-button-disabled" id="commit-button" onclick="addAndCommit()" disabled>Commit</button>
             </div>
 

--- a/app/components/footer/footer.component.html
+++ b/app/components/footer/footer.component.html
@@ -2,7 +2,7 @@
     <div class="container-fluid" style="width: 100%;">
         <div class="row">
             <div class="commit-panel col-sm-3" id="commit-panel">
-                <textarea placeholder="Describe your changes here..." class="commit-message-input" id="commit-message-input"></textarea>
+                <textarea placeholder="Describe your changes here...&#10;(Ctrl\Cmd + Enter or drag and drop to commit)" class="commit-message-input" id="commit-message-input" draggable="true" onkeypress="commitShortcut(event)" ondragstart="handleCommitBoxDragStart(event)" ondragend="handleCommitBoxDragEnd(event)"></textarea>
                 <div class="commit-button-wrapper" id="commit-button-wrapper">
                     <button class="commit-button" id="commit-button">Commit</button>
                     <button class="commit-button" id="fileEdit-button" (click)="displayFileEditor()">File Editor</button>

--- a/app/components/footer/footer.component.html
+++ b/app/components/footer/footer.component.html
@@ -2,7 +2,8 @@
     <div class="container-fluid" style="width: 100%;">
         <div class="row">
             <div class="commit-panel col-sm-3" id="commit-panel">
-                <textarea placeholder="Describe your changes here...&#10;&#10;(Ctrl\Cmd + Enter or drag and drop to commit)" rows=4 class="commit-message-input" id="commit-message-input" draggable="true" onkeypress="commitShortcut(event)" ondragstart="handleCommitBoxDragStart(event)" ondragend="handleCommitBoxDragEnd(event)"></textarea>
+                <textarea placeholder="Commit disabled...&#10;&#10;No Files Staged" disabled rows=3 class="form-control" id="commit-message-input" draggable="true" onkeypress="commitShortcut(event)" ondragstart="handleCommitBoxDragStart(event)" ondragend="handleCommitBoxDragEnd(event)"></textarea>
+                <button class="input-group-addon commit-button-disabled" id="commit-button" onclick="addAndCommit()" disabled>Commit</button>
             </div>
 
             <div class="terminal col-sm-6" id="terminal">

--- a/app/components/footer/footer.component.html
+++ b/app/components/footer/footer.component.html
@@ -2,10 +2,7 @@
     <div class="container-fluid" style="width: 100%;">
         <div class="row">
             <div class="commit-panel col-sm-3" id="commit-panel">
-                <textarea placeholder="Describe your changes here...&#10;(Ctrl\Cmd + Enter or drag and drop to commit)" class="commit-message-input" id="commit-message-input" draggable="true" onkeypress="commitShortcut(event)" ondragstart="handleCommitBoxDragStart(event)" ondragend="handleCommitBoxDragEnd(event)"></textarea>
-                <div class="commit-button-wrapper" id="commit-button-wrapper">
-                    <button class="commit-button" id="commit-button">Commit</button>
-                </div>
+                <textarea placeholder="Describe your changes here...&#10;&#10;(Ctrl\Cmd + Enter or drag and drop to commit)" rows=4 class="commit-message-input" id="commit-message-input" draggable="true" onkeypress="commitShortcut(event)" ondragstart="handleCommitBoxDragStart(event)" ondragend="handleCommitBoxDragEnd(event)"></textarea>
             </div>
 
             <div class="terminal col-sm-6" id="terminal">

--- a/app/components/header/header.component.html
+++ b/app/components/header/header.component.html
@@ -478,6 +478,10 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
         <button type="button" class="btn btn-danger" id="localDeleteButton" data-dismiss="modal" onClick="deleteUpstream()">Delete</button>
+      </div>
+    </div>
+  </div>
+</div>
 
 <!--rebase-->
 <div id="rebase-modal" class="modal fade  " tabindex="-1" role="dialog" aria-hidden="true">

--- a/app/misc/dragAndDrop.ts
+++ b/app/misc/dragAndDrop.ts
@@ -1,6 +1,5 @@
 function handleGraphDrop(event:DragEvent){
     //Intended to be easily extendable for future drag and drop handling
-    event.preventDefault();
     if(event.dataTransfer){
         //Retrieve payload and convert to JSON
         let payload = JSON.parse(event.dataTransfer!.getData("text"));
@@ -9,6 +8,9 @@ function handleGraphDrop(event:DragEvent){
         switch (payload.operation){
             case "stash":
                 popStash(payload.index);
+                break;
+            case "commit":
+                addAndCommit();
                 break;
             default:
         }
@@ -41,4 +43,20 @@ function handleStashDropZoneDrop(event:DragEvent){
             dropStash(payload.index);
         }
     }
+}
+
+function handleCommitBoxDragStart(event:DragEvent){
+    document.getElementById("graph-panel")!.classList.add("dropzone");
+    event.dataTransfer!.effectAllowed = 'move';
+    //generate data payload
+    let payload = {
+        operation: "commit",
+        index: undefined
+    };
+    event.dataTransfer!.setData("text", JSON.stringify(payload));
+}
+
+function handleCommitBoxDragEnd(event:DragEvent){
+    //remove dropzone styling
+    document.getElementById("graph-panel")!.classList.remove("dropzone");
 }

--- a/app/misc/dragAndDrop.ts
+++ b/app/misc/dragAndDrop.ts
@@ -1,19 +1,23 @@
 function handleGraphDrop(event:DragEvent){
     //Intended to be easily extendable for future drag and drop handling
     if(event.dataTransfer){
-        //Retrieve payload and convert to JSON
-        let payload = JSON.parse(event.dataTransfer!.getData("text"));
+        let payloadString = event.dataTransfer.getData("text");
+        if (payloadString != ""){
+            //Retrieve payload and convert to JSON
+            let payload = JSON.parse(payloadString);
 
-        //Perform specified operation
-        switch (payload.operation){
-            case "stash":
-                popStash(payload.index);
-                break;
-            case "commit":
-                addAndCommit();
-                break;
-            default:
+            //Perform specified operation
+            switch (payload.operation){
+                case "stash":
+                    popStash(payload.index);
+                    break;
+                case "commit":
+                    addAndCommit();
+                    break;
+                default:
+            }
         }
+        
     }
 }
 

--- a/app/misc/dragAndDrop.ts
+++ b/app/misc/dragAndDrop.ts
@@ -52,7 +52,6 @@ function handleStashDropZoneDrop(event:DragEvent){
 function handleCommitBoxDragStart(event:DragEvent){
     document.getElementById("graph-panel")!.classList.add("dropzone");
     event.dataTransfer!.effectAllowed = 'move';
-    event.dataTransfer!.setDragImage(document.createElement("div"),0,0);
     //generate data payload
     let payload = {
         operation: "commit",

--- a/app/misc/dragAndDrop.ts
+++ b/app/misc/dragAndDrop.ts
@@ -52,6 +52,7 @@ function handleStashDropZoneDrop(event:DragEvent){
 function handleCommitBoxDragStart(event:DragEvent){
     document.getElementById("graph-panel")!.classList.add("dropzone");
     event.dataTransfer!.effectAllowed = 'move';
+    event.dataTransfer!.setDragImage(document.createElement("div"),0,0);
     //generate data payload
     let payload = {
         operation: "commit",

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -116,7 +116,7 @@ function stage() {
 
   if (stagedFiles == null || stagedFiles.length !== 0) {
     if (document.getElementById("staged-files-message") !== null) {
-      document.getElementById("commit-panel")!.style.visibility = "visible";
+      enableCommit();
       let filePanelMessage = document.getElementById("staged-files-message");
       filePanelMessage.parentNode.removeChild(filePanelMessage);
     }
@@ -238,7 +238,8 @@ function clearStagedFilesList() {
   filesChangedMessage.id = "staged-files-message";
   filesChangedMessage.innerHTML = "Your staged files will appear here";
   filePanel.appendChild(filesChangedMessage);
-  document.getElementById("commit-panel")!.style.visibility = "hidden";
+  
+  disableCommit();
   changeColor();
 }
 

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -116,6 +116,7 @@ function stage() {
 
   if (stagedFiles == null || stagedFiles.length !== 0) {
     if (document.getElementById("staged-files-message") !== null) {
+      document.getElementById("commit-panel")!.style.visibility = "visible";
       let filePanelMessage = document.getElementById("staged-files-message");
       filePanelMessage.parentNode.removeChild(filePanelMessage);
     }
@@ -237,7 +238,7 @@ function clearStagedFilesList() {
   filesChangedMessage.id = "staged-files-message";
   filesChangedMessage.innerHTML = "Your staged files will appear here";
   filePanel.appendChild(filesChangedMessage);
-
+  document.getElementById("commit-panel")!.style.visibility = "hidden";
   changeColor();
 }
 

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -125,7 +125,7 @@ function stage() {
 function addAndCommit() {
   commitMessage = document.getElementById('commit-message-input').value;
   if (commitMessage == null || commitMessage == "") {
-    window.alert("Cannot commit without a commit message. Please add a commit message before committing");
+    displayModal("Cannot commit without a commit message. Please add a commit message before committing");
     return;
   }
   let repository;

--- a/app/misc/keyboardShortcuts.ts
+++ b/app/misc/keyboardShortcuts.ts
@@ -1,0 +1,6 @@
+function commitShortcut(event :KeyboardEvent){
+    console.log(event);
+    if(event.code == "Enter" && event.ctrlKey){
+        addAndCommit();
+    }
+}

--- a/app/misc/keyboardShortcuts.ts
+++ b/app/misc/keyboardShortcuts.ts
@@ -1,5 +1,4 @@
 function commitShortcut(event :KeyboardEvent){
-    console.log(event);
     if(event.code == "Enter" && event.ctrlKey){
         addAndCommit();
     }

--- a/app/misc/router.ts
+++ b/app/misc/router.ts
@@ -297,9 +297,7 @@ function hideFooter(){
 }
 function displayFooter(){
   document.getElementById("terminal")!.style.visibility = "visible";
-  if(document.getElementById("staged-files-message") == null){
-    document.getElementById("commit-panel")!.style.visibility = "visible";
-  }
+  document.getElementById("commit-panel")!.style.visibility = "visible";
   document.getElementById("stash-panel")!.style.visibility = "visible";
 }
 
@@ -362,4 +360,22 @@ function useRecentRepositories() {
     } else {
         console.log(file + ' exists')
     }
+}
+
+function enableCommit(){
+  let messageInput = <HTMLInputElement>document.getElementById("commit-message-input")!;
+  messageInput.disabled = false;
+  messageInput.placeholder = "Describe your changes here...\n\n(Ctrl + Enter or drag and drop to commit)"
+  let commitButton = <HTMLInputElement>document.getElementById("commit-button")!
+  commitButton.disabled = false;
+  commitButton.classList.remove("commit-button-disabled");
+}
+
+function disableCommit(){
+  let messageInput = <HTMLInputElement>document.getElementById("commit-message-input")!;
+  messageInput.disabled = true;
+  messageInput.placeholder = "Commit Disabled...\n\nNo Files Staged"
+  let commitButton = <HTMLInputElement>document.getElementById("commit-button")!
+  commitButton.disabled = true;
+  commitButton.classList.add("commit-button-disabled");
 }

--- a/app/misc/router.ts
+++ b/app/misc/router.ts
@@ -142,17 +142,6 @@ function displayFilePanel() {
   if (filePanel != null){
     filePanel.style.zIndex = "10";
   }
-
-  let commitMessageInput = document.getElementById("commit-message-input");
-  if (commitMessageInput != null){
-    commitMessageInput.style.visibility = "visible";
-  }
-
-  let commitButton = document.getElementById("commit-button");
-  if (commitButton != null){
-    commitButton.style.visibility = "visible";
-  }
-
 }
 
 function displayPullRequestPanel() {
@@ -189,16 +178,6 @@ function hideFilePanel() {
   let filePanel = document.getElementById("file-panel");
   if (filePanel != null){
     filePanel.style.zIndex = "-10";
-  }
-
-  let commitMessageInput = document.getElementById("commit-message-input");
-  if (commitMessageInput != null){
-    commitMessageInput.style.visibility = "hidden";
-  }
-
-  let commitButton = document.getElementById("commit-button");
-  if (commitButton != null){
-    commitButton.style.visibility = "hidden";
   }
 
  }
@@ -313,10 +292,14 @@ function hideDiffPanelButtons() {
 
 function hideFooter(){
   document.getElementById("terminal")!.style.visibility = "hidden";
+  document.getElementById("commit-panel")!.style.visibility = "hidden";
   document.getElementById("stash-panel")!.style.visibility = "hidden";
 }
 function displayFooter(){
   document.getElementById("terminal")!.style.visibility = "visible";
+  if(document.getElementById("staged-files-message") == null){
+    document.getElementById("commit-panel")!.style.visibility = "visible";
+  }
   document.getElementById("stash-panel")!.style.visibility = "visible";
 }
 

--- a/app/misc/router.ts
+++ b/app/misc/router.ts
@@ -363,6 +363,7 @@ function useRecentRepositories() {
 }
 
 function enableCommit(){
+  document.getElementById("commit-panel")!.draggable = true;
   let messageInput = <HTMLInputElement>document.getElementById("commit-message-input")!;
   messageInput.disabled = false;
   messageInput.placeholder = "Describe your changes here...\n\n(Ctrl + Enter or drag and drop to commit)"
@@ -372,6 +373,7 @@ function enableCommit(){
 }
 
 function disableCommit(){
+  document.getElementById("commit-panel")!.draggable = false;
   let messageInput = <HTMLInputElement>document.getElementById("commit-message-input")!;
   messageInput.disabled = true;
   messageInput.placeholder = "Commit Disabled...\n\nNo Files Staged"

--- a/index.html
+++ b/index.html
@@ -27,6 +27,7 @@
     <script src="app/misc/file.js"></script>
     <script src="app/misc/wiki.js"></script>
     <script src="app/misc/dragAndDrop.js"></script>
+    <script src="app/misc/keyboardShortcuts.js"></script>
     <link href="node_modules/vis/dist/vis.min.css" rel="stylesheet" type="text/css">
     <script src="node_modules/jquery/dist/jquery.js"></script>
     <script src="node_modules/bootstrap/dist/js/bootstrap.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -79,11 +79,6 @@ ipcRenderer.on('change-to-default-style', function() {
 
 document.addEventListener('DOMContentLoaded', function() {
   setTimeout(function() {
-    // Add click event to Commit button
-    document.getElementById('commit-button').addEventListener("click", function() {
-      console.log("commit button has been clicked");
-      addAndCommit();
-    });
 
     document.getElementById('save-button').addEventListener("click", function() {
       saveFile();

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -526,28 +526,8 @@ body .footer .commit-panel .commit-message-input {
   padding: 5px;
 }
 
-body .footer .commit-panel .commit-button-wrapper {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-}
-
-body .footer .commit-panel .commit-button-wrapper .commit-button {
-  display: block;
-  margin-left: 5px;
-  margin-top: 10px;
-  margin-bottom: 10px;
-  height: 30px;
-  border-radius: 10px;
-  border: 0;
-  padding: 0 14px;
-  background-color: #39c0ba;
-  color: #fff;
-  white-space: nowrap;
-}
-
-body .footer .commit-panel .commit-button:hover {
-  opacity: 0.8;
+.commit-panel{
+  visibility: hidden;
 }
 
 body .footer .terminal .git-command {

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -1388,6 +1388,7 @@ ul li {
 }
 
 #commit-message-input{
+  resize: none;
   border-bottom-left-radius: 0px;
   border-bottom-right-radius: 0px;
 }
@@ -1406,5 +1407,6 @@ ul li {
   border-color: lightgray !important;
   background-color: lightgray !important;
   color: slategray !important;
+  cursor: no-drop !important;
 }
 

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -526,10 +526,6 @@ body .footer .commit-panel .commit-message-input {
   padding: 5px;
 }
 
-.commit-panel{
-  visibility: hidden;
-}
-
 body .footer .terminal .git-command {
   margin: 10px;
 }
@@ -1385,3 +1381,25 @@ ul li {
   margin-bottom: -1px;
   border: 0.5px solid #ddd;
 }
+
+#commit-message-input{
+  border-bottom-left-radius: 0px;
+  border-bottom-right-radius: 0px;
+}
+
+#commit-button{
+  border-top-right-radius: 0px;
+  border-top-left-radius: 0px;
+  border-bottom-left-radius: 4px;
+  width: 100%;
+  color: white;
+  background-color: #337ab7;
+  border-color: #2e6da4;
+}
+
+.commit-button-disabled{
+  border-color: lightgray !important;
+  background-color: lightgray !important;
+  color: slategray !important;
+}
+

--- a/stylesheets/styles.css
+++ b/stylesheets/styles.css
@@ -522,7 +522,6 @@ body .footer .commit-panel .commit-message-input {
   margin-left: auto;
   margin-right: auto;
   margin-top: 5px;
-  height: 50px;
   border-radius: 5px;
   padding: 5px;
 }


### PR DESCRIPTION
This PR adds a few things for #186.

- Drag and drop to commit! You can now commit by dragging the commit box onto the graph

- Keyboard shortcut to commit, for the power users out there ctrl+enter will also activate the commit process.

- Commit button redesign, since the other 2 buttons are now gone the commit button looked weird on it's own

- Commit panel now disables when there are no staged files, this gives a better visual indicator of when you can and can't commit

- Lastly window.alert was causing issues with the drag and drop and was not in line with the rest of the project, this was brought in line with the rest of the project by using displaymodal instead