### PR TITLE
Hid repo clone progress bar upon failure.

### DIFF
--- a/app/misc/repo.ts
+++ b/app/misc/repo.ts
@@ -150,7 +150,6 @@ function downloadFunc(cloneURL, fullLocalPath) {
       updateProgressBar(0);
       console.log("Repo successfully cloned");
       document.getElementById('graph-loading').style.display = 'block';
-      refreshAll(repository);
       updateModalText("Clone Successful, repository saved under: " + fullLocalPath);
       addCommand("git clone " + cloneURL + " " + fullLocalPath);
       repoFullPath = fullLocalPath;
@@ -160,6 +159,8 @@ function downloadFunc(cloneURL, fullLocalPath) {
       switchToMainPanel();
     },
       function (err) {
+        progressDiv.style.visibility = 'collapse';
+        updateProgressBar(0);
         updateModalText("Clone Failed - " + err);
         console.log("repo.ts, line 64, failed to clone repo: " + err); // TODO show error on screen
         switchToAddRepositoryPanel();


### PR DESCRIPTION
Empty progress bar now is removed if a repo clone fails.
I also fixed an issue I found where there are two calls to refreshAll() when cloning. I couldn't find any reason there would be so I removed one.