### PR TITLE
Issue 172 - Edit Upstream Repo

### DIFF
--- a/app/components/header/header.component.html
+++ b/app/components/header/header.component.html
@@ -464,9 +464,27 @@
   </div>
 </div>
 
+<!-- Confirmation Modal for editing upstream -->
+<div id="edit-upstream-modal" class="modal fade">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true">&times;</button>
+        <h4 class="modal-title">Confirmation</h4>
+      </div>
+      <div class="modal-body">
+        Are you sure you want to edit the upstream repository?
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal" onClick="clearUpstreamModalText()">Close</button>
+        <button type="button" class="btn btn-warning" id="localDeleteButton" data-dismiss="modal" onClick="editUpstream()">Confirm</button>
+      </div>
+    </div>
+  </div>
+</div>
+
 <!-- Confirmation Modal for deleting upstream -->
 <div id="delete-upstream-modal" class="modal fade">
-  <!-- <input type="hidden" id="branch-to-delete" name="branch-to-delete" /> -->
   <div class="modal-dialog">
     <div class="modal-content">
       <div class="modal-header">
@@ -479,6 +497,10 @@
       <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
         <button type="button" class="btn btn-danger" id="localDeleteButton" data-dismiss="modal" onClick="deleteUpstream()">Delete</button>
+      </div>
+    </div>
+  </div>
+</div>
 
 <!--rebase-->
 <div id="rebase-modal" class="modal fade  " tabindex="-1" role="dialog" aria-hidden="true">

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -1772,6 +1772,7 @@ function editUpstream() {
     Git.Repository.open(repoFullPath)
       .then(function (repo) {
       repository = repo;
+      addCommand("git remote rm upstream");
       Git.Remote.delete(repository, 'upstream').then(function(result) {
         addCommand("git remote add upstream " + upstreamRepoPath);
         Git.Remote.createWithFetchspec(repository, 'upstream', upstreamRepoPath, '+refs/heads/*:refs/remotes/upstream/*').then(function(remote) {

--- a/app/misc/git.ts
+++ b/app/misc/git.ts
@@ -1773,6 +1773,7 @@ function editUpstream() {
       .then(function (repo) {
       repository = repo;
       Git.Remote.delete(repository, 'upstream').then(function(result) {
+        addCommand("git remote add upstream " + upstreamRepoPath);
         Git.Remote.createWithFetchspec(repository, 'upstream', upstreamRepoPath, '+refs/heads/*:refs/remotes/upstream/*').then(function(remote) {
           displayModal("Upstream repository successfully configured.");
         }, function(err){
@@ -1806,6 +1807,7 @@ function deleteUpstream() {
   let repository;
   Git.Repository.open(repoFullPath)
       .then(function (repo) {
+    addCommand("git remote rm upstream");
     Git.Remote.delete(repo, 'upstream').then(function(result) {
       displayModal('Upstream repository successfully deleted.')
     }, function(err) {


### PR DESCRIPTION
Fixes #172: Previously, in order to edit the upstream repo you had to manually delete the upstream before entering the url of the new upstream. Now, if you have an upstream configured and enter a new one, a confirmation modal will appear and ask if you want to edit the upstream.